### PR TITLE
feat: add 30m timeframe support and centralize tf resolution mapping

### DIFF
--- a/src/tradingview_mcp/core/services/screener_provider.py
+++ b/src/tradingview_mcp/core/services/screener_provider.py
@@ -1,24 +1,7 @@
 from __future__ import annotations
 from typing import List, Dict, Any, Optional
+from ..types import tf_to_tv_resolution as _tf_to_tv_resolution
 from ..utils.validators import get_market_type
-
-
-def _tf_to_tv_resolution(tf: Optional[str]) -> Optional[str]:
-    """Map our timeframe to TradingView resolution suffix used in columns.
-    Returns None if no mapping (means: no suffix).
-    """
-    if not tf:
-        return None
-    m = {
-        '5m': '5',
-        '15m': '15',
-        '1h': '60',
-        '4h': '240',
-        '1D': '1D',
-        '1W': '1W',
-        '1M': '1M',
-    }
-    return m.get(tf)
 
 
 def fetch_screener_indicators(
@@ -124,18 +107,6 @@ def fetch_screener_multi_changes(
     # Default timeframe set
     if not timeframes:
         timeframes = ['15m', '1h', '4h', '1D']
-
-    def _tf_to_tv_resolution(tf: Optional[str]) -> Optional[str]:
-        mapping = {
-            '5m': '5',
-            '15m': '15',
-            '1h': '60',
-            '4h': '240',
-            '1D': '1D',
-            '1W': '1W',
-            '1M': '1M',
-        }
-        return mapping.get(tf or '')
 
     # Build suffix map and filter invalid tfs
     suffix_map: Dict[str, str] = {}

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -358,8 +358,7 @@ def fetch_multi_timeframe_patterns(
     if not _SCREENER_AVAILABLE:
         return []
     try:
-        tf_map = {"5m": "5", "15m": "15", "1h": "60", "4h": "240", "1D": "1D"}
-        tv_interval = tf_map.get(base_tf, "15")
+        tv_interval = tf_to_tv_resolution(base_tf) or "15"
 
         cols = [
             f"open|{tv_interval}",

--- a/src/tradingview_mcp/core/types.py
+++ b/src/tradingview_mcp/core/types.py
@@ -68,6 +68,7 @@ def tf_to_tv_resolution(tf: Optional[str]) -> Optional[str]:
     return {
         "5m": "5",
         "15m": "15",
+        "30m": "30",
         "1h": "60",
         "4h": "240",
         "1D": "1D",

--- a/src/tradingview_mcp/core/utils/validators.py
+++ b/src/tradingview_mcp/core/utils/validators.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 import os
 from typing import Set
 
-ALLOWED_TIMEFRAMES: Set[str] = {"5m", "15m", "1h", "4h", "1D", "1W", "1M"}
+ALLOWED_TIMEFRAMES: Set[str] = {"5m", "15m", "30m", "1h", "4h", "1D", "1W", "1M"}
 _TIMEFRAME_ALIASES = {
     "5m": "5m",
     "15m": "15m",
+    "30m": "30m",
     "1h": "1h",
     "4h": "4h",
     "1d": "1D",

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -16,6 +16,7 @@ def test_sanitize_timeframe_accepts_uppercase_with_whitespace():
 def test_sanitize_timeframe_preserves_intraday_timeframes():
     assert sanitize_timeframe("5m") == "5m"
     assert sanitize_timeframe("15m") == "15m"
+    assert sanitize_timeframe("30m") == "30m"
     assert sanitize_timeframe("1h") == "1h"
     assert sanitize_timeframe("4h") == "4h"
 


### PR DESCRIPTION
## Summary                                                                                                     
                                      
  - **Add 30-minute timeframe support** — the `tradingview-ta` library natively supports `30m`                   
  (`Interval.INTERVAL_30_MINUTES`), but it was missing from `ALLOWED_TIMEFRAMES` and the resolution mapping.     
  Passing `"30m"` previously fell back silently to `"5m"`.                                                       
  - **Centralize the timeframe-to-resolution mapping** — three duplicate copies of the same dict existed across
  `screener_provider.py` (×2) and `screener_service.py` (×1). They were already drifting out of sync
  (`screener_service.py` was missing `1W` and `1M`). All three are now replaced with the single canonical
  `tf_to_tv_resolution()` from `core/types.py`.

  ## Changes Made

  - `core/types.py` — added `"30m": "30"` to `tf_to_tv_resolution()`
  - `core/utils/validators.py` — added `"30m"` to `ALLOWED_TIMEFRAMES`
  - `core/services/screener_provider.py` — removed 2 local mapping dicts, import from `core/types.py` instead
  - `core/services/screener_service.py` — replaced inline `tf_map` dict with existing `tf_to_tv_resolution()`
  import

  ## Testing

  - [x] `sanitize_timeframe("30m")` returns `30m` (no longer falls back to `5m`)
  - [x] `tf_to_tv_resolution("30m")` returns `30`
  - [x] Live screener call with `timeframe="30m"` returns real KuCoin data
  - [x] Existing timeframes (`5m`, `15m`, `1h`, `4h`, `1D`, `1W`, `1M`) unaffected

  ## Breaking Changes

  None — purely additive. Existing timeframes work exactly as before.
