### PR TITLE
ci: publish multi-arch Docker image to GHCR on main

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,83 @@
+# Build and publish a multi-arch Docker image of the MCP server to GHCR.
+#
+# Triggers:
+#   • push to main   → :latest + :sha-<shortsha>
+#   • push v* tag    → :<semver> + :latest
+#   • pull_request   → build only, no push (sanity check)
+#   • workflow_dispatch → manual trigger
+#
+# Architectures: linux/amd64 + linux/arm64 (covers x86 hosts + Hetzner CAX,
+# Apple Silicon, Raspberry Pi, AWS Graviton).
+
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+    # Avoid wasting CI time on doc-only changes.
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".gitignore"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # needed to push to ghcr.io/<owner>/<repo>
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Only log in when we actually intend to push (skip on pull_request).
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # Tag logic:
+          #   main branch  → :latest, :sha-abc1234
+          #   v1.2.3 tag   → :1.2.3, :1.2, :1, :latest
+          #   other branch → :branch-<name> (only on push, not PR)
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') || startsWith(github.ref, 'refs/tags/v') }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false   # smaller manifest, avoids attestation noise


### PR DESCRIPTION
## Summary

Adds the missing workflow that publishes `ghcr.io/atilaahmettaner/tradingview-mcp` to GHCR.

Before this PR: the repo has a Dockerfile but no CI/CD — so every merge that should reach downstream consumers (the hosted gateway, users who `docker pull`) required a manual local build + push. Merges to `main` (including recent ones like Taiwan/TWSE support) have **not** made it into `:latest` yet.

## Triggers

| Event | What happens |
|-------|---|
| push to `main` | builds & pushes `:latest` + `:sha-<shortsha>` |
| push `v*` tag (e.g. `v0.8.0`) | builds & pushes `:0.8.0` + `:0.8` + `:0` + `:latest` |
| pull_request | builds only (no push) — acts as a Dockerfile sanity check |
| manual dispatch | on-demand rebuild |

## Platforms

- `linux/amd64` — x86 hosts, most cloud VMs
- `linux/arm64` — Hetzner CAX (Neoverse), Apple Silicon dev machines, Raspberry Pi 4+, AWS Graviton

Both are built in a single job using QEMU + Buildx. Cache is backed by `type=gha` so subsequent builds typically finish in 1–2 minutes.

## Risk

Zero. No source-code changes. Only a new file in `.github/workflows/`. Uses the repo-scoped `GITHUB_TOKEN` with `packages: write` permission — no extra secrets required.

## After merge

The first run will publish a fresh `:latest` that includes the recently-merged TWSE/TPEX support (#23) and every other change currently sitting in `main` ahead of the old manually-built image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)