### PR TITLE
fix: support AMEX/NYSEARCA/PCX exchange aliases for NYSE Arca ETFs (GDX, GLD, XLE)

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,84 @@
+## Summary
+
+Fixes two confirmed bugs where the `exchange` parameter was ignored or incorrectly resolved when querying US ETFs (GDX, GLD, XLE) and other non-crypto assets.
+
+Closes #_ (relate to PR #23 which added TWSE/TPEX — same category of exchange-routing bugs)
+
+---
+
+## Bug 1: `multi_timeframe_analysis` hardcoded `KUCOIN:` prefix (high severity)
+
+**Symptom**: Calling `multi_timeframe_analysis(symbol="GDX", exchange="AMEX")` returned data for `KUCOIN:GDX` with all timeframes showing `"No data for {tf}"`.
+
+**Root cause**: `sanitize_exchange("AMEX", "KUCOIN")` returned `"KUCOIN"` (the fallback default) because `"amex"` was not in `EXCHANGE_SCREENER`. The subsequent symbol construction `f"{exchange.upper()}:{symbol.upper()}"` then produced `KUCOIN:GDX`.
+
+**Fix** (`src/tradingview_mcp/core/utils/validators.py`):
+- Added `"amex"`, `"nysearca"`, `"pcx"` to both `EXCHANGE_SCREENER` (→ `"america"` screener) and `STOCK_EXCHANGES`
+- Added `get_tv_exchange_prefix(exchange)` helper that returns the correct TradingView symbol prefix (e.g. `"AMEX"` for `"nysearca"`)
+- Updated `multi_timeframe_analysis` in `server.py` to use `get_tv_exchange_prefix(exchange)` instead of `exchange.upper()`
+
+---
+
+## Bug 2: `combined_analysis` / `coin_analysis` returned "No data found" for AMEX-listed ETFs (medium severity)
+
+**Symptom**: `combined_analysis(symbol="GDX", exchange="NYSE", timeframe="1D")` returned `error: "No data found for GDX on nyse"`.
+
+**Root cause**: TradingView lists NYSE Arca ETFs (GDX, GLD, XLE, SPY, QQQ, etc.) under the `AMEX:` exchange prefix, **not** `NYSE:`. `analyze_coin` built the symbol as `NYSE:GDX`, which returns no data.
+
+**Fix** (`src/tradingview_mcp/core/services/screener_service.py`):
+- `analyze_coin` now uses `get_tv_exchange_prefix(exchange)` for symbol construction
+- Users passing `exchange="NYSE"` get `NYSE:GDX` (for actual NYSE stocks), while ETF users should now pass `exchange="AMEX"`, `"NYSEARCA"`, or `"PCX"` to get `AMEX:GDX`
+
+---
+
+## New: AMEX / NYSEARCA / PCX exchange aliases
+
+TradingView uses `AMEX` as its canonical prefix for all NYSE Arca (formerly American Stock Exchange / Pacific Exchange) listings. This PR adds three accepted aliases that all resolve to `AMEX:`:
+
+| User input | Screener | Symbol prefix |
+|---|---|---|
+| `AMEX` | `america` | `AMEX:` |
+| `NYSEARCA` | `america` | `AMEX:` |
+| `PCX` | `america` | `AMEX:` |
+
+Examples that now work:
+```
+multi_timeframe_analysis(symbol="GDX", exchange="AMEX")   → AMEX:GDX ✓
+multi_timeframe_analysis(symbol="GLD", exchange="NYSEARCA") → AMEX:GLD ✓
+combined_analysis(symbol="XLE", exchange="PCX", timeframe="1D") → AMEX:XLE ✓
+coin_analysis(symbol="SPY", exchange="AMEX", timeframe="1D")   → AMEX:SPY ✓
+```
+
+---
+
+## TWSE / TPEX (Taiwan) — no changes needed
+
+TWSE and TPEX were already present in `EXCHANGE_SCREENER` (added in PR #23). Taiwan stocks like 2330, 0050, 0056 already work correctly. The `get_tv_exchange_prefix` function now makes this routing explicit and testable.
+
+---
+
+## Tests
+
+Added `tests/unit/test_exchange_fixes.py` with **32 tests** covering:
+- `sanitize_exchange` accepts `AMEX`, `NYSEARCA`, `PCX`
+- `EXCHANGE_SCREENER` and `STOCK_EXCHANGES` contain all three new aliases
+- `get_tv_exchange_prefix` maps all aliases to `"AMEX"` and handles crypto fallback
+- End-to-end symbol construction: `GDX`/`GLD`/`XLE` with any alias → `AMEX:<sym>`
+- Regression: `NYSE`, `NASDAQ`, `TWSE`, `TPEX`, `KUCOIN`, `BINANCE` unchanged
+
+```
+73 passed in 0.17s  (69 new + 4 pre-existing)
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/tradingview_mcp/core/utils/validators.py` | Add AMEX/NYSEARCA/PCX to maps; add `get_tv_exchange_prefix()` |
+| `src/tradingview_mcp/core/services/screener_service.py` | `analyze_coin`: use `get_tv_exchange_prefix` for symbol |
+| `src/tradingview_mcp/server.py` | `multi_timeframe_analysis`: use `get_tv_exchange_prefix`; update docstrings |
+| `tests/unit/test_exchange_fixes.py` | 32 new unit tests |
+| `tests/unit/test_exchange_aliases.py` | 37 additional unit tests (TWSE/TPEX symbol construction, pre-qualified symbol guard) |
+| `pyproject.toml` / `uv.lock` | Add `pytest` as dev dependency |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ where = ["src"]
 tradingview_mcp = ["coinlist/*.txt"]
 
 [tool.uv]
-dev-dependencies = []
+dev-dependencies = [
+    "pytest>=9.0.3",
+]
 package = true
 
 [build-system]

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -14,7 +14,7 @@ from tradingview_mcp.core.types import (
 )
 from tradingview_mcp.core.services.coinlist import load_symbols
 from tradingview_mcp.core.services.indicators import compute_metrics
-from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type
+from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type, get_tv_exchange_prefix
 
 try:
     from tradingview_ta import get_multiple_analysis
@@ -447,7 +447,7 @@ def analyze_coin(
     if not _TA_AVAILABLE:
         return {"error": "tradingview_ta is missing; run `uv sync`."}
 
-    full_symbol = symbol.upper() if ":" in symbol else f"{exchange.upper()}:{symbol.upper()}"
+    full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
     screener = EXCHANGE_SCREENER.get(exchange, "crypto")
 
     try:

--- a/src/tradingview_mcp/core/utils/validators.py
+++ b/src/tradingview_mcp/core/utils/validators.py
@@ -14,7 +14,15 @@ _TIMEFRAME_ALIASES = {
 }
 
 # Exchanges that represent stock markets (not crypto)
-STOCK_EXCHANGES: Set[str] = {"egx", "bist", "nasdaq", "nyse", "bursa", "myx", "klse", "ace", "leap", "hkex", "hk", "hsi", "asx", "sse", "szse", "chn", "twse", "tpex"}
+STOCK_EXCHANGES: Set[str] = {
+    "egx", "bist", "nasdaq", "nyse",
+    "amex", "nysearca", "pcx",          # NYSE Arca / AMEX (ETFs: GDX, GLD, XLE, SPY, QQQ, etc.)
+    "bursa", "myx", "klse", "ace", "leap",
+    "hkex", "hk", "hsi",
+    "asx",
+    "sse", "szse", "chn",
+    "twse", "tpex",
+}
 
 EXCHANGE_SCREENER = {
     "all": "crypto",
@@ -43,6 +51,10 @@ EXCHANGE_SCREENER = {
     "hk": "hongkong",       # Hong Kong (alternate)
     "hsi": "hongkong",      # Hang Seng Index constituents
     "nyse": "america",
+    # NYSE Arca / AMEX — ETFs (GDX, GLD, XLE, SPY, QQQ …) are listed here in TradingView
+    "amex": "america",      # TradingView canonical prefix for NYSE Arca ETFs
+    "nysearca": "america",  # alias: NYSE Arca (official name used by issuers)
+    "pcx": "america",       # alias: Pacific Exchange (historical MIC code for NYSE Arca)
     "asx": "australia",     # Australian Securities Exchange
     # China A-Share Market Support
     "sse": "china",         # Shanghai Stock Exchange (上海证券交易所)
@@ -52,6 +64,42 @@ EXCHANGE_SCREENER = {
     "twse": "taiwan",       # Taiwan Stock Exchange (臺灣證券交易所)
     "tpex": "taiwan",       # Taipei Exchange (櫃買中心, OTC market)
 }
+
+# Map validated exchange identifiers to their canonical TradingView symbol prefix.
+# TradingView uses "AMEX" as the prefix for all NYSE Arca / ETF listings; passing
+# "NYSE:GDX" returns no data even though GDX trades on NYSE Arca.
+_EXCHANGE_TV_PREFIX: dict = {
+    "amex": "AMEX",
+    "nysearca": "AMEX",
+    "pcx": "AMEX",
+    "nasdaq": "NASDAQ",
+    "nyse": "NYSE",
+    "egx": "EGX",
+    "bist": "BIST",
+    "bursa": "MYX",
+    "myx": "MYX",
+    "klse": "MYX",
+    "ace": "MYX",
+    "leap": "MYX",
+    "hkex": "HKEX",
+    "hk": "HKEX",
+    "hsi": "HSI",
+    "asx": "ASX",
+    "sse": "SSE",
+    "szse": "SZSE",
+    "chn": "SSE",
+    "twse": "TWSE",
+    "tpex": "TPEX",
+}
+
+
+def get_tv_exchange_prefix(exchange: str) -> str:
+    """Return the TradingView symbol prefix for *exchange* (e.g. ``AMEX`` for ``nysearca``).
+
+    Falls back to ``exchange.upper()`` for exchanges not in the explicit map so
+    that crypto exchanges (KUCOIN, BINANCE, …) still work as before.
+    """
+    return _EXCHANGE_TV_PREFIX.get(exchange.strip().lower(), exchange.upper())
 
 # Get absolute path to coinlist directory relative to this module
 # This file is at: src/tradingview_mcp/core/utils/validators.py

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -55,6 +55,7 @@ from tradingview_mcp.core.services.backtest_service import (
 from tradingview_mcp.core.utils.validators import (
     sanitize_timeframe,
     sanitize_exchange,
+    get_tv_exchange_prefix,
 )
 
 try:
@@ -308,8 +309,8 @@ def multi_agent_analysis(symbol: str, exchange: str = "KUCOIN", timeframe: str =
     """Run a multi-agent debate (Technical, Sentiment, Risk) for a specific symbol.
 
     Args:
-        symbol: Symbol — crypto: "BTCUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX)
-        exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, SSE, SZSE, TWSE, TPEX
+        symbol: Symbol — crypto: "BTCUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX), "GDX" (AMEX)
+        exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, AMEX, NYSEARCA, PCX, SSE, SZSE, TWSE, TPEX
         timeframe: Time interval (5m, 15m, 1h, 4h, 1D, 1W)
 
     Returns:
@@ -317,7 +318,7 @@ def multi_agent_analysis(symbol: str, exchange: str = "KUCOIN", timeframe: str =
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     timeframe = sanitize_timeframe(timeframe, "15m")
-    full_symbol = symbol.upper() if ":" in symbol else f"{exchange.upper()}:{symbol.upper()}"
+    full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
     return run_multi_agent_analysis(full_symbol, exchange, timeframe)
 
 
@@ -441,11 +442,11 @@ def multi_timeframe_analysis(symbol: str, exchange: str = "KUCOIN") -> dict:
     """Multi-timeframe alignment analysis (Weekly → Daily → 4H → 1H → 15m).
 
     Args:
-        symbol: Symbol — crypto: "BTCUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX)
-        exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, SSE, SZSE, TWSE, TPEX
+        symbol: Symbol — crypto: "BTCUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX), "GDX" (AMEX)
+        exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, AMEX, NYSEARCA, PCX, SSE, SZSE, TWSE, TPEX
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
-    full_symbol = symbol.upper() if ":" in symbol else f"{exchange.upper()}:{symbol.upper()}"
+    full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
     return run_multi_timeframe_analysis(full_symbol, exchange)
 
 
@@ -480,8 +481,8 @@ def combined_analysis(symbol: str, exchange: str = "NASDAQ", timeframe: str = "1
     """POWER TOOL: TradingView technical analysis + Reddit sentiment + Financial news.
 
     Args:
-        symbol: Asset symbol ("AAPL", "BTCUSDT", "THYAO")
-        exchange: Exchange (NASDAQ, NYSE, BINANCE, KUCOIN, MEXC, BIST, EGX)
+        symbol: Asset symbol ("AAPL", "BTCUSDT", "THYAO", "GDX")
+        exchange: Exchange (NASDAQ, NYSE, AMEX, NYSEARCA, PCX, BINANCE, KUCOIN, MEXC, BIST, EGX, TWSE, TPEX)
         timeframe: Analysis timeframe (5m, 15m, 1h, 4h, 1D, 1W)
     """
     tech = coin_analysis(symbol, exchange, timeframe)

--- a/tests/unit/test_exchange_aliases.py
+++ b/tests/unit/test_exchange_aliases.py
@@ -1,0 +1,160 @@
+"""
+Tests for Bug 1 (multi_timeframe_analysis ignores exchange parameter)
+and Bug 2 (combined_analysis / coin_analysis doesn't recognise AMEX/NYSEARCA/PCX).
+
+Root causes:
+  Bug 1 — server.py constructed the TradingView symbol prefix from exchange.upper()
+           instead of get_tv_exchange_prefix(exchange), so AMEX → "AMEX" was lost and
+           KUCOIN was used instead (sanitize_exchange fallback).
+  Bug 2 — "amex", "nysearca", "pcx" were absent from EXCHANGE_SCREENER so
+           sanitize_exchange() fell back to the "kucoin" default, causing
+           coin_analysis / combined_analysis to query the crypto screener.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tradingview_mcp.core.utils.validators import (
+    sanitize_exchange,
+    get_tv_exchange_prefix,
+    is_stock_exchange,
+    EXCHANGE_SCREENER,
+    STOCK_EXCHANGES,
+)
+
+
+# ── Bug 2: sanitize_exchange must recognise AMEX / NYSEARCA / PCX ─────────────
+
+class TestSanitizeExchangeAmexAliases:
+    """Bug 2 regression — AMEX/NYSEARCA/PCX must not fall back to crypto default."""
+
+    def test_amex_is_recognised(self):
+        """'AMEX' must survive sanitize_exchange, not collapse to 'kucoin'."""
+        assert sanitize_exchange("AMEX", "KUCOIN") == "amex"
+
+    def test_nysearca_is_recognised(self):
+        assert sanitize_exchange("NYSEARCA", "KUCOIN") == "nysearca"
+
+    def test_pcx_is_recognised(self):
+        assert sanitize_exchange("PCX", "KUCOIN") == "pcx"
+
+    def test_amex_lowercase_is_recognised(self):
+        assert sanitize_exchange("amex", "KUCOIN") == "amex"
+
+    def test_nysearca_lowercase_is_recognised(self):
+        assert sanitize_exchange("nysearca", "KUCOIN") == "nysearca"
+
+    def test_amex_routes_to_america_screener(self):
+        """All three aliases must route to the 'america' TradingView screener."""
+        assert EXCHANGE_SCREENER["amex"] == "america"
+        assert EXCHANGE_SCREENER["nysearca"] == "america"
+        assert EXCHANGE_SCREENER["pcx"] == "america"
+
+    def test_amex_aliases_are_stock_exchanges(self):
+        """AMEX/NYSEARCA/PCX must be classified as stock (not crypto) markets."""
+        assert "amex" in STOCK_EXCHANGES
+        assert "nysearca" in STOCK_EXCHANGES
+        assert "pcx" in STOCK_EXCHANGES
+
+    def test_is_stock_exchange_amex(self):
+        assert is_stock_exchange("AMEX") is True
+        assert is_stock_exchange("NYSEARCA") is True
+        assert is_stock_exchange("PCX") is True
+
+
+# ── Bug 1: get_tv_exchange_prefix must return AMEX for NYSE Arca aliases ───────
+
+class TestGetTvExchangePrefix:
+    """Bug 1 regression — symbol prefix must use TradingView's canonical code."""
+
+    def test_amex_prefix_is_amex(self):
+        """GDX lives at AMEX:GDX in TradingView, not NYSE:GDX."""
+        assert get_tv_exchange_prefix("amex") == "AMEX"
+
+    def test_nysearca_prefix_is_amex(self):
+        """NYSE Arca must also map to TradingView's 'AMEX' prefix."""
+        assert get_tv_exchange_prefix("nysearca") == "AMEX"
+
+    def test_pcx_prefix_is_amex(self):
+        assert get_tv_exchange_prefix("pcx") == "AMEX"
+
+    def test_nyse_prefix_is_nyse(self):
+        assert get_tv_exchange_prefix("nyse") == "NYSE"
+
+    def test_nasdaq_prefix_is_nasdaq(self):
+        assert get_tv_exchange_prefix("nasdaq") == "NASDAQ"
+
+    def test_twse_prefix_is_twse(self):
+        assert get_tv_exchange_prefix("twse") == "TWSE"
+
+    def test_tpex_prefix_is_tpex(self):
+        assert get_tv_exchange_prefix("tpex") == "TPEX"
+
+    def test_crypto_exchange_falls_back_to_upper(self):
+        """Crypto exchanges not in the map still get uppercased correctly."""
+        assert get_tv_exchange_prefix("kucoin") == "KUCOIN"
+        assert get_tv_exchange_prefix("binance") == "BINANCE"
+        assert get_tv_exchange_prefix("mexc") == "MEXC"
+
+    def test_full_symbol_construction_amex(self):
+        """Simulate the symbol construction in server.py for AMEX exchange."""
+        exchange = sanitize_exchange("AMEX", "KUCOIN")   # → "amex"
+        symbol = "GDX"
+        full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+        assert full_symbol == "AMEX:GDX", (
+            f"Expected AMEX:GDX but got {full_symbol!r}. "
+            "This means Bug 1 is not fixed: exchange prefix is wrong."
+        )
+
+    def test_full_symbol_construction_nysearca(self):
+        exchange = sanitize_exchange("NYSEARCA", "KUCOIN")  # → "nysearca"
+        symbol = "GDX"
+        full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+        assert full_symbol == "AMEX:GDX"
+
+    def test_full_symbol_construction_twse(self):
+        """Taiwan stock 2330 (TSMC) must get TWSE prefix."""
+        exchange = sanitize_exchange("TWSE", "KUCOIN")  # → "twse"
+        symbol = "2330"
+        full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+        assert full_symbol == "TWSE:2330"
+
+    def test_full_symbol_construction_tpex(self):
+        exchange = sanitize_exchange("TPEX", "KUCOIN")  # → "tpex"
+        symbol = "3105"
+        full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+        assert full_symbol == "TPEX:3105"
+
+    def test_pre_qualified_symbol_is_not_reprefixed(self):
+        """If caller already passes 'AMEX:GDX', the prefix must not be doubled."""
+        exchange = sanitize_exchange("AMEX", "KUCOIN")
+        symbol = "AMEX:GDX"  # already qualified
+        full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+        assert full_symbol == "AMEX:GDX"
+
+
+# ── Regression: existing exchanges still work ─────────────────────────────────
+
+class TestExistingExchangesUnchanged:
+    """Ensure previously-working exchanges are unaffected by the fix."""
+
+    @pytest.mark.parametrize("exchange,expected_screener", [
+        ("kucoin", "crypto"),
+        ("binance", "crypto"),
+        ("bybit", "crypto"),
+        ("mexc", "crypto"),
+        ("nasdaq", "america"),
+        ("nyse", "america"),
+        ("egx", "egypt"),
+        ("bist", "turkey"),
+        ("twse", "taiwan"),
+        ("tpex", "taiwan"),
+        ("sse", "china"),
+        ("szse", "china"),
+    ])
+    def test_existing_screener_routing(self, exchange, expected_screener):
+        assert EXCHANGE_SCREENER[exchange] == expected_screener
+
+    @pytest.mark.parametrize("exchange", ["kucoin", "binance", "bybit", "mexc"])
+    def test_crypto_not_in_stock_exchanges(self, exchange):
+        assert exchange not in STOCK_EXCHANGES

--- a/tests/unit/test_exchange_fixes.py
+++ b/tests/unit/test_exchange_fixes.py
@@ -1,0 +1,145 @@
+"""
+Tests for Bug 1 and Bug 2 fixes:
+  - Bug 1: multi_timeframe_analysis ignored exchange parameter (hardcoded KUCOIN prefix)
+  - Bug 2: combined_analysis / coin_analysis did not recognise AMEX/NYSEARCA/PCX aliases
+"""
+from tradingview_mcp.core.utils.validators import (
+    sanitize_exchange,
+    get_tv_exchange_prefix,
+    EXCHANGE_SCREENER,
+    STOCK_EXCHANGES,
+)
+
+
+# ── Bug 1 fix: exchange aliases now accepted by sanitize_exchange ──────────────
+
+class TestSanitizeExchangeNewAliases:
+    """sanitize_exchange must recognise AMEX, NYSEARCA, PCX as valid exchanges."""
+
+    def test_amex_is_valid_exchange(self):
+        assert sanitize_exchange("AMEX", "KUCOIN") == "amex"
+
+    def test_nysearca_is_valid_exchange(self):
+        assert sanitize_exchange("NYSEARCA", "KUCOIN") == "nysearca"
+
+    def test_pcx_is_valid_exchange(self):
+        assert sanitize_exchange("PCX", "KUCOIN") == "pcx"
+
+    def test_amex_lowercase_is_valid_exchange(self):
+        assert sanitize_exchange("amex", "KUCOIN") == "amex"
+
+    def test_unknown_exchange_still_falls_back_to_default(self):
+        assert sanitize_exchange("INVALID_EXCHANGE", "KUCOIN") == "KUCOIN"
+
+    def test_twse_still_valid(self):
+        assert sanitize_exchange("TWSE", "KUCOIN") == "twse"
+
+    def test_tpex_still_valid(self):
+        assert sanitize_exchange("TPEX", "KUCOIN") == "tpex"
+
+
+class TestExchangeScreenerNewEntries:
+    """AMEX/NYSEARCA/PCX must map to the america screener."""
+
+    def test_amex_maps_to_america_screener(self):
+        assert EXCHANGE_SCREENER["amex"] == "america"
+
+    def test_nysearca_maps_to_america_screener(self):
+        assert EXCHANGE_SCREENER["nysearca"] == "america"
+
+    def test_pcx_maps_to_america_screener(self):
+        assert EXCHANGE_SCREENER["pcx"] == "america"
+
+    def test_amex_in_stock_exchanges(self):
+        assert "amex" in STOCK_EXCHANGES
+
+    def test_nysearca_in_stock_exchanges(self):
+        assert "nysearca" in STOCK_EXCHANGES
+
+    def test_pcx_in_stock_exchanges(self):
+        assert "pcx" in STOCK_EXCHANGES
+
+
+# ── Bug 2 fix: get_tv_exchange_prefix returns correct TradingView prefix ──────
+
+class TestGetTvExchangePrefix:
+    """get_tv_exchange_prefix must return AMEX for all NYSE Arca aliases."""
+
+    def test_amex_returns_AMEX_prefix(self):
+        assert get_tv_exchange_prefix("amex") == "AMEX"
+
+    def test_nysearca_returns_AMEX_prefix(self):
+        """NYSEARCA should resolve to AMEX (TradingView's canonical prefix for NYSE Arca)."""
+        assert get_tv_exchange_prefix("nysearca") == "AMEX"
+
+    def test_pcx_returns_AMEX_prefix(self):
+        """PCX (Pacific Exchange MIC code) should resolve to AMEX."""
+        assert get_tv_exchange_prefix("pcx") == "AMEX"
+
+    def test_nasdaq_returns_NASDAQ_prefix(self):
+        assert get_tv_exchange_prefix("nasdaq") == "NASDAQ"
+
+    def test_nyse_returns_NYSE_prefix(self):
+        assert get_tv_exchange_prefix("nyse") == "NYSE"
+
+    def test_twse_returns_TWSE_prefix(self):
+        assert get_tv_exchange_prefix("twse") == "TWSE"
+
+    def test_tpex_returns_TPEX_prefix(self):
+        assert get_tv_exchange_prefix("tpex") == "TPEX"
+
+    def test_crypto_exchange_returns_uppercase_fallback(self):
+        """Crypto exchanges not in the map fall back to exchange.upper()."""
+        assert get_tv_exchange_prefix("kucoin") == "KUCOIN"
+        assert get_tv_exchange_prefix("binance") == "BINANCE"
+        assert get_tv_exchange_prefix("bybit") == "BYBIT"
+
+
+# ── End-to-end symbol construction simulation ─────────────────────────────────
+
+class TestSymbolConstruction:
+    """Simulate how multi_timeframe_analysis and coin_analysis build the TradingView symbol."""
+
+    def _build_symbol(self, raw_exchange: str, raw_symbol: str) -> str:
+        exchange = sanitize_exchange(raw_exchange, "KUCOIN")
+        prefix = get_tv_exchange_prefix(exchange)
+        return f"{prefix}:{raw_symbol.upper()}"
+
+    def test_gdx_with_amex_exchange(self):
+        """Bug 1 regression: GDX on AMEX must produce AMEX:GDX, not KUCOIN:GDX."""
+        assert self._build_symbol("AMEX", "GDX") == "AMEX:GDX"
+
+    def test_gdx_with_nysearca_exchange(self):
+        """Bug 2 regression: NYSEARCA alias must also produce AMEX:GDX."""
+        assert self._build_symbol("NYSEARCA", "GDX") == "AMEX:GDX"
+
+    def test_gdx_with_pcx_exchange(self):
+        assert self._build_symbol("PCX", "GDX") == "AMEX:GDX"
+
+    def test_gld_with_amex_exchange(self):
+        assert self._build_symbol("AMEX", "GLD") == "AMEX:GLD"
+
+    def test_xle_with_amex_exchange(self):
+        assert self._build_symbol("AMEX", "XLE") == "AMEX:XLE"
+
+    def test_nyse_stock_uses_nyse_prefix(self):
+        """Regular NYSE stocks must still get NYSE prefix."""
+        assert self._build_symbol("NYSE", "DOCN") == "NYSE:DOCN"
+
+    def test_nasdaq_stock_uses_nasdaq_prefix(self):
+        assert self._build_symbol("NASDAQ", "TSLA") == "NASDAQ:TSLA"
+
+    def test_twse_stock_uses_twse_prefix(self):
+        """Taiwan stocks must use TWSE prefix."""
+        assert self._build_symbol("TWSE", "2330") == "TWSE:2330"
+
+    def test_tpex_stock_uses_tpex_prefix(self):
+        assert self._build_symbol("TPEX", "3105") == "TPEX:3105"
+
+    def test_crypto_with_kucoin(self):
+        """Crypto fallback must still work."""
+        assert self._build_symbol("KUCOIN", "BTCUSDT") == "KUCOIN:BTCUSDT"
+
+    def test_unknown_exchange_still_falls_back_to_kucoin(self):
+        """Unrecognised exchange falls back to KUCOIN default then gets KUCOIN prefix."""
+        assert self._build_symbol("INVALID", "GDX") == "KUCOIN:GDX"

--- a/uv.lock
+++ b/uv.lock
@@ -211,6 +211,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -437,6 +446,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +501,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/86/1fa345fc17caf5d7780d2699985c03dbe186c68fee00b526813939062bb0/pandas-2.3.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab", size = 11883998, upload-time = "2025-07-07T19:19:34.267Z" },
     { url = "https://files.pythonhosted.org/packages/81/aa/e58541a49b5e6310d89474333e994ee57fea97c8aaa8fc7f00b873059bbf/pandas-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96", size = 12704705, upload-time = "2025-07-07T19:19:36.856Z" },
     { url = "https://files.pythonhosted.org/packages/d5/f9/07086f5b0f2a19872554abeea7658200824f5835c58a106fa8f2ae96a46c/pandas-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444", size = 13189044, upload-time = "2025-07-07T19:19:39.999Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -608,6 +635,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -907,14 +952,73 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
 name = "tradingview-mcp-server"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "feedparser" },
     { name = "mcp", extra = ["cli"] },
     { name = "tradingview-screener" },
     { name = "tradingview-ta" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -926,7 +1030,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = []
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "tradingview-screener"


### PR DESCRIPTION
## Summary

Fixes two confirmed bugs where the `exchange` parameter was ignored or incorrectly resolved when querying US ETFs (GDX, GLD, XLE) and other non-crypto assets.

Closes #_ (relate to PR #23 which added TWSE/TPEX — same category of exchange-routing bugs)

---

## Bug 1: `multi_timeframe_analysis` hardcoded `KUCOIN:` prefix (high severity)

**Symptom**: Calling `multi_timeframe_analysis(symbol="GDX", exchange="AMEX")` returned data for `KUCOIN:GDX` with all timeframes showing `"No data for {tf}"`.

**Root cause**: `sanitize_exchange("AMEX", "KUCOIN")` returned `"KUCOIN"` (the fallback default) because `"amex"` was not in `EXCHANGE_SCREENER`. The subsequent symbol construction `f"{exchange.upper()}:{symbol.upper()}"` then produced `KUCOIN:GDX`.

**Fix** (`src/tradingview_mcp/core/utils/validators.py`):
- Added `"amex"`, `"nysearca"`, `"pcx"` to both `EXCHANGE_SCREENER` (→ `"america"` screener) and `STOCK_EXCHANGES`
- Added `get_tv_exchange_prefix(exchange)` helper that returns the correct TradingView symbol prefix (e.g. `"AMEX"` for `"nysearca"`)
- Updated `multi_timeframe_analysis` in `server.py` to use `get_tv_exchange_prefix(exchange)` instead of `exchange.upper()`

---

## Bug 2: `combined_analysis` / `coin_analysis` returned "No data found" for AMEX-listed ETFs (medium severity)

**Symptom**: `combined_analysis(symbol="GDX", exchange="NYSE", timeframe="1D")` returned `error: "No data found for GDX on nyse"`.

**Root cause**: TradingView lists NYSE Arca ETFs (GDX, GLD, XLE, SPY, QQQ, etc.) under the `AMEX:` exchange prefix, **not** `NYSE:`. `analyze_coin` built the symbol as `NYSE:GDX`, which returns no data.

**Fix** (`src/tradingview_mcp/core/services/screener_service.py`):
- `analyze_coin` now uses `get_tv_exchange_prefix(exchange)` for symbol construction
- Users passing `exchange="NYSE"` get `NYSE:GDX` (for actual NYSE stocks), while ETF users should now pass `exchange="AMEX"`, `"NYSEARCA"`, or `"PCX"` to get `AMEX:GDX`

---

## New: AMEX / NYSEARCA / PCX exchange aliases

TradingView uses `AMEX` as its canonical prefix for all NYSE Arca (formerly American Stock Exchange / Pacific Exchange) listings. This PR adds three accepted aliases that all resolve to `AMEX:`:

| User input | Screener | Symbol prefix |
|---|---|---|
| `AMEX` | `america` | `AMEX:` |
| `NYSEARCA` | `america` | `AMEX:` |
| `PCX` | `america` | `AMEX:` |

Examples that now work:
```
multi_timeframe_analysis(symbol="GDX", exchange="AMEX")   → AMEX:GDX ✓
multi_timeframe_analysis(symbol="GLD", exchange="NYSEARCA") → AMEX:GLD ✓
combined_analysis(symbol="XLE", exchange="PCX", timeframe="1D") → AMEX:XLE ✓
coin_analysis(symbol="SPY", exchange="AMEX", timeframe="1D")   → AMEX:SPY ✓
```

---

## TWSE / TPEX (Taiwan) — no changes needed

TWSE and TPEX were already present in `EXCHANGE_SCREENER` (added in PR #23). Taiwan stocks like 2330, 0050, 0056 already work correctly. The `get_tv_exchange_prefix` function now makes this routing explicit and testable.

---

## Tests

Added `tests/unit/test_exchange_fixes.py` with **32 tests** covering:
- `sanitize_exchange` accepts `AMEX`, `NYSEARCA`, `PCX`
- `EXCHANGE_SCREENER` and `STOCK_EXCHANGES` contain all three new aliases
- `get_tv_exchange_prefix` maps all aliases to `"AMEX"` and handles crypto fallback
- End-to-end symbol construction: `GDX`/`GLD`/`XLE` with any alias → `AMEX:<sym>`
- Regression: `NYSE`, `NASDAQ`, `TWSE`, `TPEX`, `KUCOIN`, `BINANCE` unchanged

```
73 passed in 0.17s  (69 new + 4 pre-existing)
```

---

## Files changed

| File | Change |
|---|---|
| `src/tradingview_mcp/core/utils/validators.py` | Add AMEX/NYSEARCA/PCX to maps; add `get_tv_exchange_prefix()` |
| `src/tradingview_mcp/core/services/screener_service.py` | `analyze_coin`: use `get_tv_exchange_prefix` for symbol |
| `src/tradingview_mcp/server.py` | `multi_timeframe_analysis`: use `get_tv_exchange_prefix`; update docstrings |
| `tests/unit/test_exchange_fixes.py` | 32 new unit tests |
| `tests/unit/test_exchange_aliases.py` | 37 additional unit tests (TWSE/TPEX symbol construction, pre-qualified symbol guard) |
| `pyproject.toml` / `uv.lock` | Add `pytest` as dev dependency |
