### PR TITLE
fix: support TAIEX aliases for Taiwan index data

### DIFF
--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -14,7 +14,7 @@ from tradingview_mcp.core.types import (
 )
 from tradingview_mcp.core.services.coinlist import load_symbols
 from tradingview_mcp.core.services.indicators import compute_metrics
-from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type, get_tv_exchange_prefix
+from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type
 
 try:
     from tradingview_ta import get_multiple_analysis
@@ -442,12 +442,12 @@ def analyze_coin(
         compute_trade_setup,
         compute_trade_quality,
     )
-    from tradingview_mcp.core.utils.validators import is_stock_exchange
+    from tradingview_mcp.core.utils.validators import is_stock_exchange, normalize_tradingview_symbol
 
     if not _TA_AVAILABLE:
         return {"error": "tradingview_ta is missing; run `uv sync`."}
 
-    full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+    full_symbol = normalize_tradingview_symbol(symbol, exchange)
     screener = EXCHANGE_SCREENER.get(exchange, "crypto")
 
     try:

--- a/src/tradingview_mcp/core/utils/validators.py
+++ b/src/tradingview_mcp/core/utils/validators.py
@@ -92,6 +92,23 @@ _EXCHANGE_TV_PREFIX: dict = {
     "tpex": "TPEX",
 }
 
+_YAHOO_SYMBOL_ALIASES: dict = {
+    "TAIEX": "^TWII",
+    "TAIEX.TW": "^TWII",
+    "^TWII": "^TWII",
+    "TWSE:TAIEX": "^TWII",
+    "TWSE:IX0001": "^TWII",
+}
+
+_TRADINGVIEW_SYMBOL_ALIASES: dict = {
+    "TAIEX": "TWSE:IX0001",
+    "TAIEX.TW": "TWSE:IX0001",
+    "^TWII": "TWSE:IX0001",
+    "IX0001": "TWSE:IX0001",
+    "TWSE:TAIEX": "TWSE:IX0001",
+    "TWSE:IX0001": "TWSE:IX0001",
+}
+
 
 def get_tv_exchange_prefix(exchange: str) -> str:
     """Return the TradingView symbol prefix for *exchange* (e.g. ``AMEX`` for ``nysearca``).
@@ -100,6 +117,22 @@ def get_tv_exchange_prefix(exchange: str) -> str:
     that crypto exchanges (KUCOIN, BINANCE, …) still work as before.
     """
     return _EXCHANGE_TV_PREFIX.get(exchange.strip().lower(), exchange.upper())
+
+
+def normalize_yahoo_symbol(symbol: str) -> str:
+    """Return a provider-specific Yahoo Finance symbol for common user aliases."""
+    raw = (symbol or "").strip().upper()
+    return _YAHOO_SYMBOL_ALIASES.get(raw, raw)
+
+
+def normalize_tradingview_symbol(symbol: str, exchange: str) -> str:
+    """Return a fully-qualified TradingView symbol, resolving common index aliases."""
+    raw = (symbol or "").strip().upper()
+    if raw in _TRADINGVIEW_SYMBOL_ALIASES:
+        return _TRADINGVIEW_SYMBOL_ALIASES[raw]
+    if ":" in raw:
+        return raw
+    return f"{get_tv_exchange_prefix(exchange)}:{raw}"
 
 # Get absolute path to coinlist directory relative to this module
 # This file is at: src/tradingview_mcp/core/utils/validators.py

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -57,7 +57,8 @@ from tradingview_mcp.core.services.backtest_service import (
 from tradingview_mcp.core.utils.validators import (
     sanitize_timeframe,
     sanitize_exchange,
-    get_tv_exchange_prefix,
+    normalize_tradingview_symbol,
+    normalize_yahoo_symbol,
 )
 
 try:
@@ -320,7 +321,7 @@ def multi_agent_analysis(symbol: str, exchange: str = "KUCOIN", timeframe: str =
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     timeframe = sanitize_timeframe(timeframe, "15m")
-    full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+    full_symbol = normalize_tradingview_symbol(symbol, exchange)
     return run_multi_agent_analysis(full_symbol, exchange, timeframe)
 
 
@@ -448,7 +449,7 @@ def multi_timeframe_analysis(symbol: str, exchange: str = "KUCOIN") -> dict:
         exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, AMEX, NYSEARCA, PCX, SSE, SZSE, TWSE, TPEX
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
-    full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
+    full_symbol = normalize_tradingview_symbol(symbol, exchange)
     return run_multi_timeframe_analysis(full_symbol, exchange)
 
 
@@ -611,7 +612,7 @@ def yahoo_price(symbol: str) -> dict:
     Args:
         symbol: Yahoo Finance symbol — e.g. AAPL, BTC-USD, SPY, ^GSPC, EURUSD=X, THYAO.IS
     """
-    return get_price(symbol)
+    return get_price(normalize_yahoo_symbol(symbol))
 
 
 @mcp.tool()

--- a/tests/unit/test_exchange_aliases.py
+++ b/tests/unit/test_exchange_aliases.py
@@ -17,6 +17,8 @@ import pytest
 from tradingview_mcp.core.utils.validators import (
     sanitize_exchange,
     get_tv_exchange_prefix,
+    normalize_tradingview_symbol,
+    normalize_yahoo_symbol,
     is_stock_exchange,
     EXCHANGE_SCREENER,
     STOCK_EXCHANGES,
@@ -131,6 +133,29 @@ class TestGetTvExchangePrefix:
         symbol = "AMEX:GDX"  # already qualified
         full_symbol = symbol.upper() if ":" in symbol else f"{get_tv_exchange_prefix(exchange)}:{symbol.upper()}"
         assert full_symbol == "AMEX:GDX"
+
+
+# ── Taiwan index aliases ──────────────────────────────────────────────────────
+
+class TestTaiwanIndexAliases:
+    """Common TAIEX aliases should resolve to provider-specific working symbols."""
+
+    @pytest.mark.parametrize("raw", ["TAIEX", "TAIEX.TW", "^TWII", "TWSE:TAIEX", "TWSE:IX0001"])
+    def test_taiex_aliases_resolve_to_yahoo_twii(self, raw):
+        assert normalize_yahoo_symbol(raw) == "^TWII"
+
+    @pytest.mark.parametrize("raw", ["TAIEX", "TAIEX.TW", "^TWII", "IX0001"])
+    def test_taiex_aliases_resolve_to_tradingview_ix0001(self, raw):
+        assert normalize_tradingview_symbol(raw, "twse") == "TWSE:IX0001"
+
+    def test_prequalified_taiex_resolves_to_tradingview_ix0001(self):
+        assert normalize_tradingview_symbol("TWSE:TAIEX", "twse") == "TWSE:IX0001"
+
+    def test_normal_stock_symbol_still_uses_exchange_prefix(self):
+        assert normalize_tradingview_symbol("2330", "twse") == "TWSE:2330"
+
+    def test_prequalified_normal_symbol_still_survives(self):
+        assert normalize_tradingview_symbol("TWSE:2330", "twse") == "TWSE:2330"
 
 
 # ── Regression: existing exchanges still work ─────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes Taiwan index lookups for TAIEX / Taiwan Weighted Index aliases across the Yahoo Finance price tool and TradingView technical-analysis tools.

Taiwan stocks and ETFs already work after PR #23 (`TWSE:2330`, `TWSE:00878`, `TWSE:0056`, etc.). The remaining gap was the **index symbol itself**: common user inputs such as `TAIEX`, `TAIEX.TW`, and `TWSE:TAIEX` did not map to the provider-specific symbols that actually return data.

Why `IX0001`?

TradingView identifies Taiwan's capitalization-weighted index as **`IX0001`** on the Taiwan Stock Exchange. The public TradingView page is:

- `https://www.tradingview.com/symbols/TWSE-IX0001/`
- The page title / instrument name is **TSEC CAPITALIZATION WEIGHTED STOCK INDEX**
- TradingView also has a `TWSE-TAIEX` route, but the displayed instrument is still **IX0001**

So this PR does not invent a new index mapping. It connects common user-facing names (`TAIEX`, `TAIEX.TW`, `TWSE:TAIEX`) to the provider-specific symbols that actually return data:

- Yahoo Finance price data: `^TWII`
- TradingView technical data: `TWSE:IX0001`

---

## Bug 1: `yahoo_price("TAIEX.TW")` returned Yahoo 404

**Symptom**: Calling:

```python
yahoo_price(symbol="TAIEX.TW")
```

returned:

```json
{ "symbol": "TAIEX.TW", "error": "HTTP Error 404: Not Found", "source": "Yahoo Finance" }
```

**Root cause**: Yahoo Finance does not use `TAIEX.TW` for the Taiwan Weighted Index. Its working symbol is `^TWII`.

**Fix** (`src/tradingview_mcp/core/utils/validators.py`, `src/tradingview_mcp/server.py`):
- Added `normalize_yahoo_symbol(symbol)`
- Mapped common Taiwan index aliases to `^TWII`
- Updated `yahoo_price()` to normalize before calling Yahoo Finance

Aliases now accepted by `yahoo_price()`:

| User input | Yahoo symbol |
|---|---|
| `TAIEX` | `^TWII` |
| `TAIEX.TW` | `^TWII` |
| `^TWII` | `^TWII` |
| `TWSE:TAIEX` | `^TWII` |
| `TWSE:IX0001` | `^TWII` |

This alias list is intentionally conservative. It only includes names confirmed during local MCP testing or provider-visible routes. It does **not** try to accept broad natural-language labels such as `"Taiwan Weighted Index"` or `"TSEC Weighted Index"` because those are better handled by an intent/parser layer, not by low-level symbol normalization.

---

## Bug 2: `combined_analysis("TAIEX", exchange="TWSE")` returned no TradingView technical data

**Symptom**: Calling:

```python
combined_analysis(symbol="TAIEX", exchange="TWSE", timeframe="1D")
```

returned technical data with:

```json
{ "error": "No data found for TAIEX on twse" }
```

**Root cause**: TradingView technical-analysis data for the Taiwan Weighted Index is available under `TWSE:IX0001`, not `TWSE:TAIEX`.

**Fix** (`src/tradingview_mcp/core/utils/validators.py`, `src/tradingview_mcp/core/services/screener_service.py`, `src/tradingview_mcp/server.py`):
- Added `normalize_tradingview_symbol(symbol, exchange)`
- Mapped common Taiwan index aliases to `TWSE:IX0001`
- Updated `analyze_coin()`, `multi_timeframe_analysis()`, and `multi_agent_analysis()` to use the shared normalizer
- Kept normal stock / ETF behavior unchanged

Aliases now accepted by TradingView technical tools:

| User input | TradingView symbol |
|---|---|
| `TAIEX` | `TWSE:IX0001` |
| `TAIEX.TW` | `TWSE:IX0001` |
| `^TWII` | `TWSE:IX0001` |
| `IX0001` | `TWSE:IX0001` |
| `TWSE:TAIEX` | `TWSE:IX0001` |
| `TWSE:IX0001` | `TWSE:IX0001` |

---

## Examples that now work

```python
yahoo_price(symbol="TAIEX.TW")
# -> ^TWII, price data for Taiwan Weighted Index

yahoo_price(symbol="TWSE:TAIEX")
# -> ^TWII, price data for Taiwan Weighted Index

combined_analysis(symbol="TAIEX", exchange="TWSE", timeframe="1D")
# -> technical.symbol = TWSE:IX0001

combined_analysis(symbol="TWSE:TAIEX", exchange="TWSE", timeframe="1D")
# -> technical.symbol = TWSE:IX0001

multi_timeframe_analysis(symbol="TAIEX.TW", exchange="TWSE")
# -> symbol = TWSE:IX0001
```

Normal Taiwan stocks and ETFs still behave as before:

```python
normalize_tradingview_symbol("2330", "twse")      # TWSE:2330
normalize_tradingview_symbol("TWSE:2330", "twse") # TWSE:2330
```

---

## Tests

Added Taiwan index alias coverage to `tests/unit/test_exchange_aliases.py`:

- Yahoo alias normalization: `TAIEX`, `TAIEX.TW`, `^TWII`, `TWSE:TAIEX`, `TWSE:IX0001` → `^TWII`
- TradingView alias normalization: `TAIEX`, `TAIEX.TW`, `^TWII`, `IX0001`, `TWSE:TAIEX` → `TWSE:IX0001`
- Regression: normal TWSE symbols still use `TWSE:<symbol>`
- Regression: pre-qualified normal symbols are not re-prefixed

```bash
env TMPDIR=/tmp uv run pytest tests/unit -q
# 85 passed in 0.14s
```

---

## MCP smoke verification

Verified against a local MCP server launched from this branch:

```bash
uv run tradingview-mcp stdio
```

Observed results:

| Tool call | Result |
|---|---|
| `yahoo_price(symbol="TAIEX.TW")` | returns `^TWII`, price `40769.29` |
| `yahoo_price(symbol="TWSE:TAIEX")` | returns `^TWII`, price `40769.29` |
| `combined_analysis(symbol="TAIEX", exchange="TWSE", timeframe="1D")` | technical symbol `TWSE:IX0001` |
| `combined_analysis(symbol="TWSE:TAIEX", exchange="TWSE", timeframe="1D")` | technical symbol `TWSE:IX0001` |
| `multi_timeframe_analysis(symbol="TAIEX.TW", exchange="TWSE")` | symbol `TWSE:IX0001` |

Sample technical signal from the smoke probe:

```json
{
  "symbol": "TWSE:IX0001",
  "price_data": {
    "current_price": 40769.29,
    "open": 40708.4,
    "high": 40885.05,
    "low": 40522.78,
    "close": 40769.29
  },
  "rsi": {
    "value": 76.45,
    "signal": "Overbought"
  }
}
```

---

## Files changed

| File | Change |
|---|---|
| `src/tradingview_mcp/core/utils/validators.py` | Add Yahoo and TradingView symbol alias normalizers for Taiwan index symbols |
| `src/tradingview_mcp/core/services/screener_service.py` | `analyze_coin`: use `normalize_tradingview_symbol()` |
| `src/tradingview_mcp/server.py` | `yahoo_price`, `multi_timeframe_analysis`, `multi_agent_analysis`: use shared symbol normalizers |
| `tests/unit/test_exchange_aliases.py` | Add Taiwan index alias and regression tests |
