### PR TITLE
Add Codex plugin MCP metadata

### DIFF
--- a/.codex-mcp.json
+++ b/.codex-mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "tradingview-mcp-server",
+        "tradingview-mcp"
+      ]
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "tradingview-mcp",
+  "version": "0.7.1",
+  "description": "TradingView MCP server for market prices, screeners, sentiment, backtesting, and technical analysis.",
+  "author": {
+    "name": "TradingView MCP contributors"
+  },
+  "homepage": "https://github.com/atilaahmettaner/tradingview-mcp",
+  "repository": "https://github.com/atilaahmettaner/tradingview-mcp",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "tradingview",
+    "market-data",
+    "technical-analysis",
+    "backtesting"
+  ],
+  "mcpServers": "./.codex-mcp.json",
+  "interface": {
+    "displayName": "TradingView MCP",
+    "shortDescription": "Market data and technical-analysis MCP tools",
+    "longDescription": "TradingView MCP server for market prices, screeners, sentiment, backtesting, and 30+ technical-analysis tools.",
+    "developerName": "TradingView MCP contributors",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive"
+    ],
+    "websiteURL": "https://github.com/atilaahmettaner/tradingview-mcp",
+    "defaultPrompt": [
+      "Show me the available TradingView MCP tools",
+      "Analyze BTCUSDT with TradingView MCP",
+      "Find today's top gainers with TradingView MCP"
+    ],
+    "brandColor": "#2962FF"
+  }
+}

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -4,7 +4,7 @@
 
 - **Python 3.8+** (Python 3.10+ recommended)
 - **UV Package Manager** (for dependency management)
-- **Claude Desktop** (for MCP integration)
+- **Claude Desktop or Codex** (for MCP integration)
 - **Internet Connection** (for TradingView data access)
 
 ## Step-by-Step Installation
@@ -35,7 +35,37 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 uv --version
 ```
 
-### 2. Configure Claude Desktop
+### 2. Configure Your MCP Client
+
+#### Codex Plugin
+
+This repository includes mcp-only Codex plugin metadata:
+
+- `.codex-plugin/plugin.json`
+- `.codex-mcp.json`
+
+The bundled Codex MCP configuration uses the PyPI package:
+
+```json
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "tradingview-mcp-server",
+        "tradingview-mcp"
+      ]
+    }
+  }
+}
+```
+
+After enabling the plugin in Codex, restart Codex so the MCP server is loaded in the next session.
+
+Depending on your Codex version, `codex mcp list` may show registered MCP servers. To verify tool availability, start a fresh Codex session and ask it to show the available TradingView tools.
+
+#### Claude Desktop
 
 #### Find Claude Desktop Config File:
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ pip install tradingview-mcp-server
 
 On Linux, replace `/Users/YOUR_USERNAME` with `/home/YOUR_USERNAME`. On Windows, use `%USERPROFILE%\.local\bin\uvx.exe`.
 
+### Codex Plugin Config
+
+This repository also includes mcp-only Codex plugin metadata:
+
+- `.codex-plugin/plugin.json`
+- `.codex-mcp.json`
+
+The plugin uses the same PyPI package entrypoint:
+
+```json
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "uvx",
+      "args": ["--from", "tradingview-mcp-server", "tradingview-mcp"]
+    }
+  }
+}
+```
+
+After installing or enabling the Codex plugin, restart Codex so the MCP server is loaded in the next session. Depending on your Codex version, `codex mcp list` may show registered MCP servers, but tool availability should be verified in a fresh Codex session.
+
 ### Or run from source
 ```bash
 git clone https://github.com/atilaahmettaner/tradingview-mcp


### PR DESCRIPTION
## Summary
- Add mcp-only Codex plugin metadata via `.codex-plugin/plugin.json`.
- Add `.codex-mcp.json` pointing Codex at the existing PyPI entrypoint: `uvx --from tradingview-mcp-server tradingview-mcp`.
- Document Codex plugin setup in README and INSTALLATION without changing the existing Claude Desktop setup.

## Verification
- `python3 -m json.tool .codex-plugin/plugin.json`
- `python3 -m json.tool .codex-mcp.json`
- `git diff --check`
- MCP smoke: launched the PyPI package command and listed tools successfully; returned 27 tools including `combined_analysis`, `backtest_strategy`, and `advanced_candle_pattern`.

## Notes
This keeps Codex support mcp-only. No skills, local fork paths, personal paths, or workflow-specific instructions are included.