### PR TITLE
fix: replace dead Reuters RSS feeds with live Yahoo/MarketWatch/CNBC

### DIFF
--- a/src/tradingview_mcp/core/services/news_service.py
+++ b/src/tradingview_mcp/core/services/news_service.py
@@ -6,8 +6,13 @@ No API keys required. Pulls from free, public RSS feeds.
 
 Sources:
   crypto: CoinDesk, Cointelegraph
-  stocks: Reuters Business News
+  stocks: Yahoo Finance, MarketWatch (Top + Real-Time), CNBC
   all:    Combined
+
+Note (2026-05-14): Original Reuters feeds (feeds.reuters.com) are deprecated
+since ~2020 — they return zero entries. Replaced with Yahoo Finance,
+MarketWatch, and CNBC which return live data. A `User-Agent` header is
+required for some publishers (Yahoo, CNBC) to serve the feed correctly.
 """
 from __future__ import annotations
 
@@ -29,16 +34,23 @@ RSS_FEEDS: dict[str, list[dict]] = {
         {"url": "https://cointelegraph.com/rss", "name": "CoinTelegraph"},
     ],
     "stocks": [
-        {"url": "https://feeds.reuters.com/reuters/businessNews", "name": "Reuters Business"},
-        {"url": "https://feeds.reuters.com/reuters/companyNews", "name": "Reuters Company"},
+        {"url": "https://finance.yahoo.com/news/rssindex", "name": "Yahoo Finance"},
+        {"url": "https://feeds.content.dowjones.io/public/rss/mw_topstories", "name": "MarketWatch Top Stories"},
+        {"url": "https://feeds.content.dowjones.io/public/rss/mw_realtimeheadlines", "name": "MarketWatch Real-Time"},
+        {"url": "https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100003114", "name": "CNBC Top News"},
     ],
     "all": [
-        {"url": "https://feeds.reuters.com/reuters/businessNews", "name": "Reuters Business"},
+        {"url": "https://finance.yahoo.com/news/rssindex", "name": "Yahoo Finance"},
+        {"url": "https://feeds.content.dowjones.io/public/rss/mw_topstories", "name": "MarketWatch Top Stories"},
+        {"url": "https://search.cnbc.com/rs/search/combinedcms/view.xml?partnerId=wrss01&id=100003114", "name": "CNBC Top News"},
         {"url": "https://www.coindesk.com/arc/outboundfeeds/rss/", "name": "CoinDesk"},
         {"url": "https://cointelegraph.com/rss", "name": "CoinTelegraph"},
     ],
 }
 
+# Some publishers (Yahoo, CNBC) return empty feeds to the default urllib UA.
+# Setting a browser-like UA produces live data.
+_FEED_USER_AGENT = "Mozilla/5.0 (compatible; tradingview-mcp/0.7.1; +https://github.com/atilaahmettaner/tradingview-mcp)"
 _TIMEOUT = 8
 
 
@@ -74,7 +86,7 @@ def fetch_news(
         if len(results) >= limit:
             break
         try:
-            feed = feedparser.parse(feed_info["url"])
+            feed = feedparser.parse(feed_info["url"], agent=_FEED_USER_AGENT)
             source_name = feed.feed.get("title", feed_info["name"])
 
             for entry in feed.entries:


### PR DESCRIPTION
## Problem

`financial_news` has been silently returning `count: 0` for `category="stocks"`. Caller sees no error — just empty results — and may not realize the tool is broken.

Root cause: the Reuters public RSS feeds (`feeds.reuters.com/reuters/businessNews`, `feeds.reuters.com/reuters/companyNews`) were deprecated around 2020. `feedparser` fetches the URL, finds no entries, returns an empty list. The MCP tool wraps that into `{"count": 0, "items": []}` and returns success.

Verified 2026-05-14 with direct feedparser calls:

```
Reuters Business (current)   HTTP=n/a entries=0
Reuters Company  (current)   HTTP=n/a entries=0
```

## Fix

Replace the dead Reuters feeds with currently-live, public, no-auth alternatives:

| Feed | HTTP | Entries |
|------|-----:|--------:|
| Yahoo Finance | 200 | 49 |
| MarketWatch Top Stories | 200 | 10 |
| MarketWatch Real-Time | 200 | 10 |
| CNBC Top News | 200 | 30 |

Yahoo and CNBC require a browser-like `User-Agent` header to serve the feed correctly — added `_FEED_USER_AGENT` constant and threaded it through `feedparser.parse(url, agent=...)`.

Crypto feeds (CoinDesk, Cointelegraph) unchanged — both still live; verified in the same regression test.

## Verification

After the patch:
```
stocks: count=10 (was 0)
AAPL filter: count=0 (Yahoo headlines use "Apple" not "AAPL")
crypto: count=5 (regression — unchanged)
```

## Notes

- Symbol filter remains best-effort substring match against title + summary. Per-ticker hit rate is lower with Yahoo/MarketWatch/CNBC than it was with Reuters because these publishers use company names ("Nvidia") rather than tickers ("NVDA") in headlines. A ticker→company name lookup would improve this but was kept out of this PR to keep the diff small. Happy to add it as a follow-up if you'd like.
- No new dependencies. Same return shape.

## Related

Builds on the resilience layer from #32 (already merged). The same maintainer recently added `bitcoin_market_pulse` (#28) and `stock_extended_hours` (#29), so the news side staying broken stood out as an asymmetry.
