### PR TITLE
feat: fundamentals, risk & investment-thesis tools (9 new MCP tools)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,8 @@ __marimo__/
 test_nyse.py
 scripts/fetch_nyse_tickers.py
 .claude/
+# Local MCP server config — contains user-specific absolute paths
+.mcp.json
 
 # AI Agent skills — local only, never commit
 .agents/

--- a/scripts/smoke_http.ps1
+++ b/scripts/smoke_http.ps1
@@ -1,0 +1,66 @@
+# Smoke test: hit the streamable-http MCP server and list registered tools.
+# Verifies that the 9 new tools (fundamentals, risk, thesis) loaded cleanly.
+
+$ErrorActionPreference = "Stop"
+$endpoint = "http://127.0.0.1:8000/mcp"
+
+# Step 1: initialize an MCP session
+$initBody = @{
+    jsonrpc = "2.0"
+    id      = 1
+    method  = "initialize"
+    params  = @{
+        protocolVersion = "2024-11-05"
+        capabilities    = @{}
+        clientInfo      = @{ name = "smoke-script"; version = "0.1" }
+    }
+} | ConvertTo-Json -Depth 10 -Compress
+
+$headers = @{
+    "Content-Type" = "application/json"
+    "Accept"       = "application/json, text/event-stream"
+}
+
+$response = Invoke-WebRequest -Uri $endpoint -Method Post -Body $initBody -Headers $headers
+$sessionId = $response.Headers["Mcp-Session-Id"] | Select-Object -First 1
+if (-not $sessionId) { Write-Error "no session id returned"; exit 1 }
+Write-Output "session: $sessionId"
+
+# Step 2: send initialized notification (required handshake)
+$initializedBody = @{ jsonrpc = "2.0"; method = "notifications/initialized" } | ConvertTo-Json -Compress
+$headersWithSession = $headers + @{ "Mcp-Session-Id" = $sessionId }
+Invoke-WebRequest -Uri $endpoint -Method Post -Body $initializedBody -Headers $headersWithSession | Out-Null
+
+# Step 3: list tools
+$listBody = @{ jsonrpc = "2.0"; id = 2; method = "tools/list" } | ConvertTo-Json -Compress
+$resp = Invoke-WebRequest -Uri $endpoint -Method Post -Body $listBody -Headers $headersWithSession
+$body = $resp.Content
+
+# Streamable HTTP can return SSE format. Strip the SSE wrapper if present.
+if ($body -match "^data: (.+)$") {
+    $body = $Matches[1]
+}
+# Sometimes there are multiple SSE frames; grab the last "data:" line
+$dataLines = $body -split "`n" | Where-Object { $_ -match "^data: " } | ForEach-Object { $_ -replace "^data: ", "" }
+if ($dataLines) { $body = $dataLines[-1] }
+
+$parsed = $body | ConvertFrom-Json
+$tools = $parsed.result.tools | ForEach-Object { $_.name } | Sort-Object
+
+Write-Output ""
+Write-Output "=== Registered tools ($($tools.Count)) ==="
+$tools | ForEach-Object { Write-Output "  $_" }
+
+$expectedNew = @(
+    "stock_fundamentals", "compare_peers", "dividend_info",
+    "position_sizing", "risk_reward_calc", "kelly_position_size",
+    "correlation_matrix", "value_at_risk_analysis", "investment_thesis"
+)
+$missing = $expectedNew | Where-Object { $_ -notin $tools }
+Write-Output ""
+if ($missing) {
+    Write-Output "FAIL: missing tools: $($missing -join ', ')"
+    exit 1
+} else {
+    Write-Output "PASS: all 9 new tools registered"
+}

--- a/src/tradingview_mcp/core/services/fundamentals_service.py
+++ b/src/tradingview_mcp/core/services/fundamentals_service.py
@@ -1,0 +1,478 @@
+"""
+Fundamentals Service — Yahoo Finance quoteSummary endpoint.
+
+Why this exists: a real investment analyst doesn't decide on a position from
+charts alone — they look at the business behind the ticker. This service
+pulls valuation multiples, profitability ratios, growth, balance-sheet
+health, and dividend info in one call.
+
+Data source: Yahoo Finance quoteSummary API (free, no key). Same proxy
+infrastructure as yahoo_finance_service. Returns error dicts on failure
+rather than raising, matching the rest of the codebase.
+
+Symbols supported: anything Yahoo recognises — AAPL, MSFT, TSLA, THYAO.IS,
+SASA.IS, COMI.CA, etc. Crypto (BTC-USD) has limited fundamental data;
+we return what's available without erroring.
+"""
+from __future__ import annotations
+
+import http.cookiejar
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+from tradingview_mcp.core.services.proxy_manager import build_opener_with_proxy
+
+_TIMEOUT = 15
+_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+_BASE = "https://query2.finance.yahoo.com/v10/finance/quoteSummary"
+
+_MODULES = (
+    "summaryDetail,defaultKeyStatistics,financialData,"
+    "incomeStatementHistory,balanceSheetHistory,cashflowStatementHistory,"
+    "calendarEvents,price"
+)
+
+# Yahoo started gating quoteSummary behind a crumb+cookie session in 2024.
+# Cache the session for ~25min so we don't re-handshake on every call.
+_CRUMB_CACHE: dict = {"crumb": None, "cookies": None, "ts": 0.0}
+_CRUMB_TTL_SECONDS = 1500
+
+
+def _new_session_opener() -> urllib.request.OpenerDirector:
+    cj = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+    opener.addheaders = [
+        ("User-Agent", _UA),
+        ("Accept", "application/json, text/plain, */*"),
+        ("Accept-Language", "en-US,en;q=0.9"),
+    ]
+    return opener
+
+
+def _get_crumb_and_opener() -> tuple[str, urllib.request.OpenerDirector]:
+    """Establish a Yahoo session: cookies via fc.yahoo.com, then crumb token.
+
+    Cached for 25 minutes. Returns (crumb_string, opener_with_cookies).
+    """
+    now = time.time()
+    if _CRUMB_CACHE["crumb"] and (now - _CRUMB_CACHE["ts"]) < _CRUMB_TTL_SECONDS:
+        return _CRUMB_CACHE["crumb"], _CRUMB_CACHE["opener"]
+
+    opener = _new_session_opener()
+    # Step 1: hit fc.yahoo.com to drop session cookies
+    try:
+        opener.open("https://fc.yahoo.com/", timeout=_TIMEOUT)
+    except urllib.error.HTTPError:
+        pass  # any HTTP status is fine — we just need Set-Cookie
+    except urllib.error.URLError:
+        pass
+
+    # Step 2: ask for a crumb token
+    req = urllib.request.Request(
+        "https://query2.finance.yahoo.com/v1/test/getcrumb",
+        headers={"User-Agent": _UA, "Accept": "text/plain"},
+    )
+    with opener.open(req, timeout=_TIMEOUT) as resp:
+        crumb = resp.read().decode("utf-8").strip()
+    if not crumb or len(crumb) > 100:
+        raise ValueError(f"unexpected crumb response: {crumb[:80]!r}")
+
+    _CRUMB_CACHE.update(crumb=crumb, opener=opener, ts=now)
+    return crumb, opener
+
+
+def _fetch(symbol: str) -> dict:
+    try:
+        crumb, opener = _get_crumb_and_opener()
+    except (urllib.error.URLError, ValueError) as e:
+        raise ValueError(f"Yahoo crumb handshake failed: {e}")
+
+    url = f"{_BASE}/{symbol}?modules={_MODULES}&crumb={urllib.parse.quote(crumb)}"
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": _UA, "Accept": "application/json"},
+    )
+    try:
+        with opener.open(req, timeout=_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        # Crumb may have expired — invalidate cache and retry once
+        if e.code in (401, 403):
+            _CRUMB_CACHE["crumb"] = None
+            crumb, opener = _get_crumb_and_opener()
+            url = f"{_BASE}/{symbol}?modules={_MODULES}&crumb={urllib.parse.quote(crumb)}"
+            req = urllib.request.Request(
+                url, headers={"User-Agent": _UA, "Accept": "application/json"}
+            )
+            with opener.open(req, timeout=_TIMEOUT) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        else:
+            raise
+
+    result = data.get("quoteSummary", {}).get("result")
+    if not result:
+        err = data.get("quoteSummary", {}).get("error") or "no result"
+        raise ValueError(f"Yahoo returned no fundamentals: {err}")
+    return result[0]
+
+
+def _raw(node: dict, key: str) -> Optional[float]:
+    """Yahoo wraps numerics as {raw: x, fmt: "..."}; pull the raw."""
+    v = node.get(key)
+    if isinstance(v, dict):
+        return v.get("raw")
+    return v
+
+
+def _pct(value: Optional[float]) -> Optional[float]:
+    """Yahoo returns fractions (0.234) for ratios — convert to percent for display."""
+    if value is None:
+        return None
+    return round(value * 100, 2)
+
+
+def _label_pe(pe: Optional[float]) -> str:
+    if pe is None or pe <= 0:
+        return "N/A (negative earnings or unavailable)"
+    if pe < 15:
+        return "Undervalued vs market"
+    if pe < 25:
+        return "Fair value"
+    if pe < 40:
+        return "Premium / growth-priced"
+    return "Expensive — priced for perfection"
+
+
+def _label_debt_equity(de: Optional[float]) -> str:
+    if de is None:
+        return "N/A"
+    # Yahoo returns the raw ratio (e.g. 1.5 means 150%). Some tickers report
+    # this as a percentage already (150 instead of 1.5). Normalise both ways.
+    val = de / 100 if de > 5 else de
+    if val < 0.5:
+        return "Conservative balance sheet"
+    if val < 1.0:
+        return "Moderate leverage"
+    if val < 2.0:
+        return "High leverage"
+    return "Heavy debt load — risk of distress"
+
+
+def _label_roe(roe_pct: Optional[float]) -> str:
+    if roe_pct is None:
+        return "N/A"
+    if roe_pct < 0:
+        return "Loss-making — capital being destroyed"
+    if roe_pct < 10:
+        return "Below average return on equity"
+    if roe_pct < 20:
+        return "Healthy return on equity"
+    return "Exceptional return on equity"
+
+
+def get_fundamentals(symbol: str) -> dict:
+    """Fetch valuation, profitability, growth, balance sheet, and verdict.
+
+    Args:
+        symbol: Yahoo Finance ticker — AAPL, MSFT, TSLA, THYAO.IS, etc.
+
+    Returns:
+        Structured dict with sections: identity, valuation, profitability,
+        growth, balance_sheet, dividend, verdict. Missing fields are None,
+        not omitted, so consumers can format consistently.
+    """
+    symbol = symbol.upper().strip()
+    try:
+        node = _fetch(symbol)
+    except (urllib.error.URLError, json.JSONDecodeError, ValueError) as e:
+        return {"symbol": symbol, "error": f"{type(e).__name__}: {e}", "source": "Yahoo Finance"}
+
+    summary = node.get("summaryDetail", {})
+    stats = node.get("defaultKeyStatistics", {})
+    fin = node.get("financialData", {})
+    price = node.get("price", {})
+
+    pe_trailing = _raw(summary, "trailingPE")
+    pe_forward = _raw(summary, "forwardPE")
+    pb = _raw(stats, "priceToBook")
+    ps = _raw(summary, "priceToSalesTrailing12Months")
+    market_cap = _raw(price, "marketCap")
+    enterprise_value = _raw(stats, "enterpriseValue")
+    ev_ebitda = _raw(stats, "enterpriseToEbitda")
+
+    eps_trailing = _raw(stats, "trailingEps")
+    eps_forward = _raw(stats, "forwardEps")
+    roe = _pct(_raw(fin, "returnOnEquity"))
+    roa = _pct(_raw(fin, "returnOnAssets"))
+    profit_margin = _pct(_raw(fin, "profitMargins"))
+    operating_margin = _pct(_raw(fin, "operatingMargins"))
+
+    revenue_growth = _pct(_raw(fin, "revenueGrowth"))
+    earnings_growth = _pct(_raw(fin, "earningsGrowth"))
+    total_revenue = _raw(fin, "totalRevenue")
+    free_cash_flow = _raw(fin, "freeCashflow")
+    operating_cash_flow = _raw(fin, "operatingCashflow")
+
+    debt_to_equity = _raw(fin, "debtToEquity")
+    current_ratio = _raw(fin, "currentRatio")
+    quick_ratio = _raw(fin, "quickRatio")
+    total_cash = _raw(fin, "totalCash")
+    total_debt = _raw(fin, "totalDebt")
+
+    dividend_yield = _pct(_raw(summary, "dividendYield"))
+    dividend_rate = _raw(summary, "dividendRate")
+    payout_ratio = _pct(_raw(summary, "payoutRatio"))
+    ex_div = summary.get("exDividendDate", {})
+    ex_div_ts = ex_div.get("raw") if isinstance(ex_div, dict) else None
+    ex_div_date = (
+        datetime.fromtimestamp(ex_div_ts, tz=timezone.utc).strftime("%Y-%m-%d")
+        if ex_div_ts else None
+    )
+
+    target_high = _raw(fin, "targetHighPrice")
+    target_low = _raw(fin, "targetLowPrice")
+    target_mean = _raw(fin, "targetMeanPrice")
+    analyst_recommendation = fin.get("recommendationKey")
+    analyst_count = _raw(fin, "numberOfAnalystOpinions")
+
+    # ── Verdict synthesis ─────────────────────────────────────────────
+    flags_bullish: list[str] = []
+    flags_bearish: list[str] = []
+
+    if pe_trailing and 0 < pe_trailing < 20:
+        flags_bullish.append(f"P/E {pe_trailing:.1f} below growth-stock threshold")
+    elif pe_trailing and pe_trailing > 40:
+        flags_bearish.append(f"P/E {pe_trailing:.1f} priced for high growth")
+
+    if roe and roe > 15:
+        flags_bullish.append(f"ROE {roe:.1f}% indicates efficient capital use")
+    elif roe is not None and roe < 5:
+        flags_bearish.append(f"ROE {roe:.1f}% — weak return on equity")
+
+    if revenue_growth and revenue_growth > 15:
+        flags_bullish.append(f"Revenue growing {revenue_growth:.1f}% YoY")
+    elif revenue_growth is not None and revenue_growth < 0:
+        flags_bearish.append(f"Revenue contracting {revenue_growth:.1f}% YoY")
+
+    if free_cash_flow and free_cash_flow > 0 and market_cap:
+        fcf_yield = free_cash_flow / market_cap * 100
+        if fcf_yield > 5:
+            flags_bullish.append(f"FCF yield {fcf_yield:.1f}% — strong cash generation")
+
+    if debt_to_equity is not None:
+        de_norm = debt_to_equity / 100 if debt_to_equity > 5 else debt_to_equity
+        if de_norm > 2:
+            flags_bearish.append(f"Debt/Equity {de_norm:.2f} — heavy leverage")
+
+    if profit_margin is not None and profit_margin < 0:
+        flags_bearish.append(f"Operating at a loss ({profit_margin:.1f}% margin)")
+
+    bull_count = len(flags_bullish)
+    bear_count = len(flags_bearish)
+    if bull_count >= 3 and bear_count == 0:
+        verdict = "STRONG_FUNDAMENTAL_BUY"
+    elif bull_count > bear_count + 1:
+        verdict = "FUNDAMENTAL_BUY"
+    elif bear_count > bull_count + 1:
+        verdict = "FUNDAMENTAL_SELL"
+    elif bear_count >= 3:
+        verdict = "STRONG_FUNDAMENTAL_SELL"
+    else:
+        verdict = "FUNDAMENTAL_HOLD"
+
+    return {
+        "symbol": symbol,
+        "name": price.get("longName") or price.get("shortName"),
+        "sector": stats.get("category"),
+        "currency": price.get("currency"),
+        "source": "Yahoo Finance",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "valuation": {
+            "market_cap": market_cap,
+            "enterprise_value": enterprise_value,
+            "pe_trailing": pe_trailing,
+            "pe_forward": pe_forward,
+            "price_to_book": pb,
+            "price_to_sales": ps,
+            "ev_to_ebitda": ev_ebitda,
+            "pe_assessment": _label_pe(pe_trailing),
+        },
+        "profitability": {
+            "eps_trailing": eps_trailing,
+            "eps_forward": eps_forward,
+            "roe_pct": roe,
+            "roa_pct": roa,
+            "profit_margin_pct": profit_margin,
+            "operating_margin_pct": operating_margin,
+            "roe_assessment": _label_roe(roe),
+        },
+        "growth": {
+            "revenue_growth_yoy_pct": revenue_growth,
+            "earnings_growth_yoy_pct": earnings_growth,
+            "total_revenue_ttm": total_revenue,
+        },
+        "cash_flow": {
+            "free_cash_flow": free_cash_flow,
+            "operating_cash_flow": operating_cash_flow,
+            "fcf_yield_pct": (
+                round(free_cash_flow / market_cap * 100, 2)
+                if (free_cash_flow and market_cap) else None
+            ),
+        },
+        "balance_sheet": {
+            "debt_to_equity": debt_to_equity,
+            "current_ratio": current_ratio,
+            "quick_ratio": quick_ratio,
+            "total_cash": total_cash,
+            "total_debt": total_debt,
+            "leverage_assessment": _label_debt_equity(debt_to_equity),
+        },
+        "dividend": {
+            "yield_pct": dividend_yield,
+            "rate_annual": dividend_rate,
+            "payout_ratio_pct": payout_ratio,
+            "ex_dividend_date": ex_div_date,
+        },
+        "analyst_targets": {
+            "mean": target_mean,
+            "high": target_high,
+            "low": target_low,
+            "recommendation": analyst_recommendation,
+            "analyst_count": analyst_count,
+        },
+        "verdict": {
+            "label": verdict,
+            "bullish_factors": flags_bullish,
+            "bearish_factors": flags_bearish,
+            "bull_score": bull_count,
+            "bear_score": bear_count,
+        },
+    }
+
+
+def compare_peers(symbols: list[str]) -> dict:
+    """Side-by-side fundamental comparison across multiple tickers.
+
+    Returns a rows-of-metrics table plus per-metric leader. Useful for
+    "is AAPL cheaper than MSFT and NVDA right now?" questions.
+    """
+    symbols = [s.upper().strip() for s in symbols if s and s.strip()][:8]
+    if not symbols:
+        return {"error": "no symbols provided"}
+
+    rows: list[dict] = []
+    for s in symbols:
+        f = get_fundamentals(s)
+        if "error" in f:
+            rows.append({"symbol": s, "error": f["error"]})
+            continue
+        rows.append({
+            "symbol": s,
+            "name": f.get("name"),
+            "market_cap": f["valuation"]["market_cap"],
+            "pe_trailing": f["valuation"]["pe_trailing"],
+            "pe_forward": f["valuation"]["pe_forward"],
+            "price_to_book": f["valuation"]["price_to_book"],
+            "ev_to_ebitda": f["valuation"]["ev_to_ebitda"],
+            "roe_pct": f["profitability"]["roe_pct"],
+            "profit_margin_pct": f["profitability"]["profit_margin_pct"],
+            "revenue_growth_pct": f["growth"]["revenue_growth_yoy_pct"],
+            "debt_to_equity": f["balance_sheet"]["debt_to_equity"],
+            "dividend_yield_pct": f["dividend"]["yield_pct"],
+            "fcf_yield_pct": f["cash_flow"]["fcf_yield_pct"],
+            "verdict": f["verdict"]["label"],
+        })
+
+    def _leader(metric: str, higher_better: bool) -> Optional[str]:
+        candidates = [
+            (r["symbol"], r[metric]) for r in rows
+            if r.get(metric) is not None and not isinstance(r.get(metric), str)
+        ]
+        if not candidates:
+            return None
+        if metric == "pe_trailing" or metric == "pe_forward" or metric == "ev_to_ebitda" or metric == "price_to_book":
+            candidates = [(s, v) for s, v in candidates if v > 0]
+            if not candidates:
+                return None
+        candidates.sort(key=lambda x: x[1], reverse=higher_better)
+        return candidates[0][0]
+
+    leaders = {
+        "cheapest_pe":         _leader("pe_trailing",       higher_better=False),
+        "highest_growth":      _leader("revenue_growth_pct", higher_better=True),
+        "highest_roe":         _leader("roe_pct",            higher_better=True),
+        "highest_margin":      _leader("profit_margin_pct",  higher_better=True),
+        "lowest_leverage":     _leader("debt_to_equity",     higher_better=False),
+        "highest_fcf_yield":   _leader("fcf_yield_pct",      higher_better=True),
+        "highest_dividend":    _leader("dividend_yield_pct", higher_better=True),
+    }
+
+    return {
+        "symbols": symbols,
+        "comparison": rows,
+        "leaders": leaders,
+        "source": "Yahoo Finance",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def get_dividend_info(symbol: str) -> dict:
+    """Standalone dividend-focused view: yield, payout, sustainability flags.
+
+    For income investors who only care about the dividend story.
+    """
+    f = get_fundamentals(symbol)
+    if "error" in f:
+        return f
+
+    div = f["dividend"]
+    fcf = f["cash_flow"]["free_cash_flow"]
+    payout = div.get("payout_ratio_pct")
+    yield_pct = div.get("yield_pct")
+
+    sustainability: list[str] = []
+    if payout is not None:
+        if payout < 50:
+            sustainability.append("Low payout ratio — strong room to grow dividend")
+        elif payout < 75:
+            sustainability.append("Moderate payout ratio — dividend likely safe")
+        elif payout < 100:
+            sustainability.append("High payout ratio — limited cushion")
+        else:
+            sustainability.append("Payout > 100% — dividend funded from outside earnings, risk of cut")
+
+    if fcf is not None and div.get("rate_annual") is not None and fcf > 0:
+        sustainability.append(f"FCF positive ({fcf:,.0f}) — supports cash dividend payments")
+    elif fcf is not None and fcf < 0:
+        sustainability.append("FCF negative — dividend not currently covered by cash flow")
+
+    if yield_pct is None or yield_pct == 0:
+        income_grade = "NON_PAYING"
+    elif yield_pct < 2:
+        income_grade = "LOW_YIELD"
+    elif yield_pct < 4:
+        income_grade = "STANDARD_YIELD"
+    elif yield_pct < 7:
+        income_grade = "HIGH_YIELD"
+    else:
+        income_grade = "ULTRA_HIGH_YIELD_CHECK_FOR_TRAPS"
+
+    return {
+        "symbol": f["symbol"],
+        "name": f.get("name"),
+        "yield_pct": yield_pct,
+        "annual_rate": div.get("rate_annual"),
+        "payout_ratio_pct": payout,
+        "ex_dividend_date": div.get("ex_dividend_date"),
+        "income_grade": income_grade,
+        "sustainability_notes": sustainability,
+        "source": "Yahoo Finance",
+    }

--- a/src/tradingview_mcp/core/services/investment_thesis_service.py
+++ b/src/tradingview_mcp/core/services/investment_thesis_service.py
@@ -1,0 +1,385 @@
+"""
+Investment Thesis Service — full investment-grade report on a single symbol.
+
+Why this exists: existing tools each answer one question (technicals,
+sentiment, fundamentals, news). A real analyst's deliverable is a SINGLE
+document that pulls all of them into bull case, bear case, valuation,
+catalysts, risks, and a verdict with conviction.
+
+This service orchestrates — no new data sources, just synthesis:
+  - Technical:    coin_analysis (TradingView indicators)
+  - Fundamental:  get_fundamentals (Yahoo quoteSummary)
+  - Sentiment:    analyze_sentiment (Reddit) — optional
+  - News:         fetch_news_summary (RSS) — optional
+  - Macro (crypto): get_bitcoin_market_pulse — optional
+  - Risk:         value_at_risk on the position — optional
+
+Each upstream call is wrapped in try/except so a single failed dependency
+doesn't kill the thesis. Missing sections are flagged in `data_quality`
+so the consumer can see what's incomplete.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from tradingview_mcp.core.services.fundamentals_service import get_fundamentals
+from tradingview_mcp.core.services.screener_service import analyze_coin
+from tradingview_mcp.core.services.sentiment_service import analyze_sentiment
+from tradingview_mcp.core.services.news_service import fetch_news_summary
+from tradingview_mcp.core.services.bitcoin_market_service import get_bitcoin_market_pulse
+from tradingview_mcp.core.services.risk_service import value_at_risk
+
+
+_CRYPTO_EXCHANGES = {"BINANCE", "KUCOIN", "BYBIT", "MEXC", "OKX", "GATEIO", "COINBASE", "HUOBI", "BITFINEX", "BITGET"}
+
+
+def _is_crypto(exchange: str) -> bool:
+    return exchange.upper() in _CRYPTO_EXCHANGES
+
+
+def _safe(fn, *args, **kwargs):
+    """Call fn but never raise — return (result, error_message)."""
+    try:
+        out = fn(*args, **kwargs)
+        if isinstance(out, dict) and "error" in out:
+            return None, out["error"]
+        return out, None
+    except Exception as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+def _to_yahoo_symbol(symbol: str, exchange: str) -> str:
+    """Map TradingView-style symbols to Yahoo Finance equivalents.
+
+    - Crypto: BTCUSDT (Binance/KuCoin) → BTC-USD (Yahoo)
+    - BIST:   THYAO → THYAO.IS
+    - SSE:    600519 → 600519.SS
+    - SZSE:   300251 → 300251.SZ
+    - TWSE:   2330 → 2330.TW
+    - HKEX:   00700 → 0700.HK
+    - EGX:    COMI → COMI.CA
+    - NASDAQ/NYSE/AMEX: leave as-is
+    """
+    s = symbol.upper().replace(":", "").strip()
+    e = exchange.upper()
+
+    if _is_crypto(e):
+        for quote in ("USDT", "BUSD", "USDC", "USD"):
+            if s.endswith(quote):
+                base = s[: -len(quote)]
+                return f"{base}-USD"
+        return s
+
+    suffix_map = {
+        "BIST": ".IS",
+        "SSE": ".SS",
+        "SZSE": ".SZ",
+        "TWSE": ".TW",
+        "TPEX": ".TWO",
+        "HKEX": ".HK",
+        "EGX": ".CA",
+        "BURSA": ".KL",
+        "KLSE": ".KL",
+    }
+    suffix = suffix_map.get(e)
+    if suffix and not s.endswith(suffix):
+        return f"{s}{suffix}"
+    return s
+
+
+def _verdict_from_signals(scores: dict) -> tuple[str, str, list[str]]:
+    """Aggregate signed scores into final verdict + conviction + reasoning.
+
+    Each input contributes a signed weight; we sum and bucket the total.
+    Reasoning list shows which signals agreed and which conflicted.
+    """
+    total = sum(scores.values())
+    n_inputs = len([v for v in scores.values() if v != 0])
+    agreement: list[str] = []
+
+    if total >= 4:
+        verdict = "STRONG_BUY"
+    elif total >= 2:
+        verdict = "BUY"
+    elif total <= -4:
+        verdict = "STRONG_SELL"
+    elif total <= -2:
+        verdict = "SELL"
+    else:
+        verdict = "HOLD"
+
+    positives = [k for k, v in scores.items() if v > 0]
+    negatives = [k for k, v in scores.items() if v < 0]
+
+    if n_inputs >= 3 and len(positives) >= n_inputs - 1 and not negatives:
+        conviction = "HIGH"
+        agreement.append("All signals align bullish — high-conviction setup.")
+    elif n_inputs >= 3 and len(negatives) >= n_inputs - 1 and not positives:
+        conviction = "HIGH"
+        agreement.append("All signals align bearish — high-conviction warning.")
+    elif positives and negatives:
+        conviction = "LOW"
+        agreement.append(
+            f"Mixed signals: bullish {positives} vs bearish {negatives}. "
+            "Wait for confluence or reduce position size."
+        )
+    elif n_inputs <= 1:
+        conviction = "LOW"
+        agreement.append("Limited data — only one signal available. Treat as preliminary.")
+    else:
+        conviction = "MEDIUM"
+        agreement.append(f"Partial confluence: {positives or negatives}")
+
+    return verdict, conviction, agreement
+
+
+def generate_investment_thesis(
+    symbol: str,
+    exchange: str = "NASDAQ",
+    timeframe: str = "1D",
+    position_value: Optional[float] = None,
+    include_news: bool = True,
+    include_sentiment: bool = True,
+) -> dict:
+    """Build a structured investment thesis pulling every dimension together.
+
+    Args:
+        symbol: Asset symbol (AAPL, BTCUSDT, THYAO, etc.)
+        exchange: Exchange — crypto: KUCOIN/BINANCE/MEXC; stocks: NASDAQ/NYSE/BIST/EGX...
+        timeframe: Technical analysis timeframe (1D recommended for investing horizon)
+        position_value: If provided, add VaR risk section sized to this dollar exposure.
+        include_news: Pull RSS news headlines (slower; disable for speed).
+        include_sentiment: Pull Reddit sentiment (slower; disable for speed).
+
+    Returns:
+        Multi-section dict: identity, technical, fundamental, sentiment, news,
+        macro_context, risk, bull_case, bear_case, catalysts, price_targets,
+        verdict, data_quality.
+    """
+    symbol_clean = symbol.upper().strip()
+    # sanitize_exchange (called in the MCP wrapper) returns the lowercase
+    # canonical form that EXCHANGE_SCREENER expects. Pass it through verbatim
+    # to analyze_coin; only uppercase the copy used for Yahoo-symbol mapping.
+    exchange_canonical = exchange.strip().lower()
+    is_crypto = _is_crypto(exchange_canonical)
+    yahoo_sym = _to_yahoo_symbol(symbol_clean, exchange_canonical)
+
+    bull_case: list[str] = []
+    bear_case: list[str] = []
+    catalysts: list[str] = []
+    risks: list[str] = []
+    scores: dict[str, int] = {}
+    data_quality: dict[str, str] = {}
+
+    # ── 1. Technical analysis ────────────────────────────────────────────
+    # analyze_coin handles the exchange prefix internally; pass the raw symbol
+    # to match the convention used by combined_analysis.
+    tech, tech_err = _safe(analyze_coin, symbol_clean, exchange_canonical, timeframe)
+    if tech_err:
+        data_quality["technical"] = f"failed: {tech_err}"
+        tech_signal = None
+    else:
+        data_quality["technical"] = "ok"
+        ms = tech.get("market_sentiment", {}) if isinstance(tech, dict) else {}
+        tech_signal = ms.get("buy_sell_signal") or ms.get("recommendation")
+        momentum = ms.get("momentum", "")
+
+        if tech_signal in ("STRONG_BUY", "BUY"):
+            scores["technical"] = 2 if tech_signal == "STRONG_BUY" else 1
+            bull_case.append(f"Technical: {tech_signal} on {timeframe} — {momentum or 'positive momentum'}.")
+        elif tech_signal in ("STRONG_SELL", "SELL"):
+            scores["technical"] = -2 if tech_signal == "STRONG_SELL" else -1
+            bear_case.append(f"Technical: {tech_signal} on {timeframe} — {momentum or 'negative momentum'}.")
+        else:
+            scores["technical"] = 0
+
+        indicators = tech.get("indicators", {}) if isinstance(tech, dict) else {}
+        rsi = indicators.get("RSI")
+        if rsi is not None:
+            if rsi < 30:
+                bull_case.append(f"RSI {rsi:.1f} — oversold, mean-reversion setup possible.")
+            elif rsi > 70:
+                bear_case.append(f"RSI {rsi:.1f} — overbought, vulnerable to pullback.")
+
+    # ── 2. Fundamental (only meaningful for stocks) ──────────────────────
+    if not is_crypto:
+        fund, fund_err = _safe(get_fundamentals, yahoo_sym)
+        if fund_err or not fund:
+            data_quality["fundamental"] = f"failed: {fund_err}"
+            fund = None
+        else:
+            data_quality["fundamental"] = "ok"
+            v = fund.get("verdict", {})
+            label = v.get("label", "")
+            if "STRONG_FUNDAMENTAL_BUY" in label:
+                scores["fundamental"] = 2
+            elif "FUNDAMENTAL_BUY" in label:
+                scores["fundamental"] = 1
+            elif "STRONG_FUNDAMENTAL_SELL" in label:
+                scores["fundamental"] = -2
+            elif "FUNDAMENTAL_SELL" in label:
+                scores["fundamental"] = -1
+            else:
+                scores["fundamental"] = 0
+
+            for f in v.get("bullish_factors", []):
+                bull_case.append(f"Fundamental: {f}.")
+            for f in v.get("bearish_factors", []):
+                bear_case.append(f"Fundamental: {f}.")
+
+            targets = fund.get("analyst_targets", {})
+            mean_t = targets.get("mean")
+            current_price = None
+            try:
+                current_price = tech.get("price", {}).get("close") if tech else None
+            except Exception:
+                pass
+            if mean_t and current_price:
+                upside = (mean_t - current_price) / current_price * 100
+                if upside > 15:
+                    catalysts.append(f"Analyst mean target ${mean_t:.2f} implies {upside:+.1f}% upside.")
+                elif upside < -10:
+                    risks.append(f"Analyst mean target ${mean_t:.2f} implies {upside:+.1f}% downside.")
+    else:
+        fund = None
+        data_quality["fundamental"] = "skipped (crypto)"
+
+    # ── 3. Sentiment (Reddit) ────────────────────────────────────────────
+    if include_sentiment:
+        cat = "crypto" if is_crypto else "stocks"
+        sent_base = symbol_clean.replace("USDT", "").replace("-USD", "")
+        sent, sent_err = _safe(analyze_sentiment, sent_base, cat, 20)
+        if sent_err or not sent:
+            data_quality["sentiment"] = f"failed: {sent_err}"
+            sent = None
+        else:
+            data_quality["sentiment"] = "ok"
+            score = sent.get("sentiment_score", 0)
+            label = sent.get("sentiment_label", "")
+            n_posts = sent.get("posts_analyzed", 0)
+            if n_posts < 5:
+                data_quality["sentiment"] = f"thin ({n_posts} posts)"
+            if score > 0.25:
+                scores["sentiment"] = 1
+                bull_case.append(f"Reddit sentiment: {label} ({score:+.2f}, {n_posts} posts).")
+            elif score < -0.25:
+                scores["sentiment"] = -1
+                bear_case.append(f"Reddit sentiment: {label} ({score:+.2f}, {n_posts} posts).")
+            else:
+                scores["sentiment"] = 0
+    else:
+        sent = None
+        data_quality["sentiment"] = "skipped"
+
+    # ── 4. News headlines ────────────────────────────────────────────────
+    if include_news:
+        cat = "crypto" if is_crypto else "stocks"
+        news_base = symbol_clean.replace("USDT", "").replace("-USD", "")
+        news, news_err = _safe(fetch_news_summary, news_base, cat, 5)
+        if news_err or not news:
+            data_quality["news"] = f"failed: {news_err}"
+            news = None
+        else:
+            data_quality["news"] = "ok"
+            items = news.get("items", [])[:3]
+            for it in items:
+                title = it.get("title", "")
+                if title:
+                    catalysts.append(f"News: {title}")
+    else:
+        news = None
+        data_quality["news"] = "skipped"
+
+    # ── 5. Macro context (crypto only — BTC pulse) ───────────────────────
+    macro = None
+    if is_crypto:
+        macro, macro_err = _safe(get_bitcoin_market_pulse)
+        if macro_err or not macro:
+            data_quality["macro"] = f"failed: {macro_err}"
+            macro = None
+        else:
+            data_quality["macro"] = "ok"
+            assessment = macro.get("assessment", {})
+            label = assessment.get("label", "")
+            if label in ("HIGH_RISK", "ALT_RISK"):
+                scores["macro"] = -1
+                risks.append(f"Macro: BTC environment is {label} — {assessment.get('summary', '')}")
+            elif label == "ALT_FAVORABLE":
+                scores["macro"] = 1
+                bull_case.append(f"Macro: BTC environment is {label} — {assessment.get('summary', '')}")
+            elif label == "OPPORTUNITY_WITH_CAUTION":
+                scores["macro"] = 0
+                catalysts.append(f"Macro: {assessment.get('summary', '')}")
+
+    # ── 6. Risk sizing (only if position_value provided) ────────────────
+    risk_block = None
+    if position_value and position_value > 0:
+        risk_block, risk_err = _safe(value_at_risk, yahoo_sym, position_value, "6mo", 0.95, 1)
+        if risk_err or not risk_block:
+            data_quality["risk"] = f"failed: {risk_err}"
+            risk_block = None
+        else:
+            data_quality["risk"] = "ok"
+            hist = risk_block.get("historical_var", {})
+            loss_dollars = hist.get("loss_dollars", 0)
+            if loss_dollars:
+                risks.append(
+                    f"1-day 95% VaR: ${abs(loss_dollars):,.0f} possible loss on "
+                    f"${position_value:,.0f} position (historical method)."
+                )
+
+    # ── 7. Aggregate verdict ─────────────────────────────────────────────
+    verdict, conviction, reasoning = _verdict_from_signals(scores)
+
+    # ── 8. Price targets ─────────────────────────────────────────────────
+    price_targets = {}
+    if fund:
+        targets = fund.get("analyst_targets", {})
+        price_targets = {
+            "analyst_mean": targets.get("mean"),
+            "analyst_high": targets.get("high"),
+            "analyst_low": targets.get("low"),
+            "analyst_recommendation": targets.get("recommendation"),
+        }
+    if tech and isinstance(tech, dict):
+        setup = tech.get("trade_setup", {}) or {}
+        if setup:
+            price_targets["technical_entry"] = setup.get("entry")
+            price_targets["technical_stop"] = setup.get("stop_loss")
+            price_targets["technical_target"] = setup.get("take_profit")
+
+    return {
+        "symbol": symbol_clean,
+        "exchange": exchange_canonical,
+        "yahoo_symbol": yahoo_sym,
+        "timeframe": timeframe,
+        "asset_class": "crypto" if is_crypto else "equity",
+        "company_name": (fund.get("name") if fund else None),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+
+        "verdict": {
+            "label": verdict,
+            "conviction": conviction,
+            "score_breakdown": scores,
+            "total_score": sum(scores.values()),
+            "reasoning": reasoning,
+        },
+
+        "bull_case": bull_case,
+        "bear_case": bear_case,
+        "catalysts": catalysts,
+        "risks": risks,
+        "price_targets": price_targets,
+
+        "sections": {
+            "technical": tech,
+            "fundamental": fund,
+            "sentiment": sent,
+            "news": news,
+            "macro_context": macro,
+            "risk_sizing": risk_block,
+        },
+
+        "data_quality": data_quality,
+    }

--- a/src/tradingview_mcp/core/services/risk_service.py
+++ b/src/tradingview_mcp/core/services/risk_service.py
@@ -1,0 +1,420 @@
+"""
+Risk & Position Sizing Service — money management math for investors.
+
+Why this exists: technical analysis tells you WHAT to buy, this service tells
+you HOW MUCH. A great setup with the wrong size is still a losing strategy.
+Covers:
+  - Position sizing from account size + risk budget + stop distance
+  - Kelly Criterion for optimal bet fraction
+  - R-multiple / risk-reward calculator
+  - Historical correlation matrix between assets
+  - Value at Risk (VaR) — historical + parametric
+
+Pure math except for VaR/correlation, which need price history. We fetch
+that from Yahoo's chart endpoint directly (same as yahoo_finance_service)
+to keep the dependency footprint zero.
+
+All functions return error dicts on bad input rather than raising, so the
+MCP layer can surface them to the user verbatim.
+"""
+from __future__ import annotations
+
+import json
+import math
+import statistics
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+from tradingview_mcp.core.services.proxy_manager import build_opener_with_proxy
+
+_TIMEOUT = 12
+_UA = "tradingview-mcp/0.7.1"
+_CHART = "https://query1.finance.yahoo.com/v8/finance/chart"
+
+
+# ── Helpers: price history fetch ──────────────────────────────────────────────
+
+def _fetch_closes(symbol: str, period: str = "6mo", interval: str = "1d") -> list[float]:
+    url = f"{_CHART}/{symbol}?interval={interval}&range={period}"
+    req = urllib.request.Request(url, headers={"User-Agent": _UA, "Accept": "application/json"})
+    opener = build_opener_with_proxy(_UA)
+    with opener.open(req, timeout=_TIMEOUT) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    result = data["chart"]["result"][0]
+    raw = result["indicators"]["quote"][0]["close"]
+    return [c for c in raw if c is not None]
+
+
+def _returns(closes: list[float]) -> list[float]:
+    """Daily log returns from a close series."""
+    out: list[float] = []
+    for i in range(1, len(closes)):
+        prev, cur = closes[i - 1], closes[i]
+        if prev <= 0 or cur <= 0:
+            continue
+        out.append(math.log(cur / prev))
+    return out
+
+
+# ── Position sizing ───────────────────────────────────────────────────────────
+
+def position_size(
+    account_size: float,
+    risk_pct: float,
+    entry: float,
+    stop: float,
+    asset_price_currency: str = "USD",
+) -> dict:
+    """How many units to buy given account size, max-risk %, and stop distance.
+
+    The classic 1-2% rule made explicit:
+      risk_dollars = account_size * risk_pct/100
+      units = risk_dollars / |entry - stop|
+
+    Args:
+        account_size: Total trading capital
+        risk_pct: % of account willing to lose if stop hits (typically 0.5-2)
+        entry: Planned entry price
+        stop: Planned stop-loss price (below entry for long, above for short)
+        asset_price_currency: Display currency
+
+    Returns:
+        Recommended unit count, total position value, exposure %, and a
+        warning if exposure exceeds 25% (over-concentration).
+    """
+    if account_size <= 0:
+        return {"error": "account_size must be positive"}
+    if risk_pct <= 0 or risk_pct > 100:
+        return {"error": "risk_pct must be in (0, 100]"}
+    if entry <= 0 or stop <= 0:
+        return {"error": "entry and stop must be positive"}
+    if entry == stop:
+        return {"error": "entry and stop cannot be equal — no defined risk"}
+
+    direction = "LONG" if stop < entry else "SHORT"
+    risk_per_unit = abs(entry - stop)
+    risk_dollars = account_size * (risk_pct / 100)
+    units = risk_dollars / risk_per_unit
+    position_value = units * entry
+    exposure_pct = position_value / account_size * 100
+
+    warnings: list[str] = []
+    if exposure_pct > 100:
+        warnings.append(
+            f"Exposure {exposure_pct:.0f}% of account — requires leverage. "
+            "Consider widening stop or reducing risk_pct."
+        )
+    elif exposure_pct > 25:
+        warnings.append(
+            f"Exposure {exposure_pct:.0f}% concentrates significant capital "
+            "in a single position. Diversification suffers."
+        )
+
+    stop_distance_pct = risk_per_unit / entry * 100
+    if stop_distance_pct < 0.5:
+        warnings.append("Stop very tight (<0.5%) — noise may stop you out prematurely.")
+    elif stop_distance_pct > 20:
+        warnings.append("Stop very wide (>20%) — questionable risk/reward unless catalyst-driven.")
+
+    return {
+        "direction": direction,
+        "account_size": account_size,
+        "risk_pct": risk_pct,
+        "risk_dollars": round(risk_dollars, 2),
+        "entry": entry,
+        "stop": stop,
+        "risk_per_unit": round(risk_per_unit, 4),
+        "stop_distance_pct": round(stop_distance_pct, 2),
+        "units_to_buy": round(units, 4),
+        "position_value": round(position_value, 2),
+        "exposure_pct_of_account": round(exposure_pct, 2),
+        "currency": asset_price_currency,
+        "warnings": warnings,
+    }
+
+
+# ── Risk / Reward ─────────────────────────────────────────────────────────────
+
+def risk_reward(entry: float, stop: float, target: float) -> dict:
+    """R-multiple calculator: how many R's of profit per R of risk.
+
+    Pro traders won't take a trade below 2R; institutional swing setups
+    target 3R+. Below 1R means you risk more than you stand to make —
+    a structural negative-edge bet that no win rate can save.
+    """
+    if entry <= 0 or stop <= 0 or target <= 0:
+        return {"error": "entry, stop, target must all be positive"}
+
+    risk = abs(entry - stop)
+    reward = abs(target - entry)
+    if risk == 0:
+        return {"error": "entry equals stop — undefined risk"}
+
+    r_multiple = reward / risk
+    direction = "LONG" if target > entry else "SHORT"
+
+    # Sanity check: target should be on the opposite side of entry from stop
+    if direction == "LONG" and stop > entry:
+        return {"error": "for LONG (target > entry), stop must be below entry"}
+    if direction == "SHORT" and stop < entry:
+        return {"error": "for SHORT (target < entry), stop must be above entry"}
+
+    if r_multiple >= 3:
+        grade = "EXCELLENT"
+        note = "3R+ — institutional-grade setup; tolerates low win rate."
+    elif r_multiple >= 2:
+        grade = "GOOD"
+        note = "2-3R — solid risk/reward; viable with >40% win rate."
+    elif r_multiple >= 1:
+        grade = "MARGINAL"
+        note = "1-2R — needs >50% win rate to be profitable after costs."
+    else:
+        grade = "POOR"
+        note = "<1R — risking more than you stand to win. Skip or restructure."
+
+    breakeven_winrate_pct = round(1 / (1 + r_multiple) * 100, 1)
+
+    return {
+        "direction": direction,
+        "entry": entry,
+        "stop": stop,
+        "target": target,
+        "risk_per_unit": round(risk, 4),
+        "reward_per_unit": round(reward, 4),
+        "r_multiple": round(r_multiple, 2),
+        "grade": grade,
+        "note": note,
+        "breakeven_winrate_pct": breakeven_winrate_pct,
+    }
+
+
+# ── Kelly Criterion ───────────────────────────────────────────────────────────
+
+def kelly_criterion(
+    win_rate_pct: float,
+    win_loss_ratio: float,
+    capital: float = 10000.0,
+    kelly_fraction: float = 0.5,
+) -> dict:
+    """Kelly bet sizing: optimal % of capital to risk per trade.
+
+    Formula:  f* = W - (1 - W) / R     where W = win rate, R = avg_win/avg_loss
+
+    Full Kelly is mathematically optimal but emotionally unbearable —
+    drawdowns can be 50%+. Most pros use Half Kelly (0.5x) or Quarter Kelly.
+
+    Args:
+        win_rate_pct: Historical win rate, e.g. 55 for 55%
+        win_loss_ratio: Average win size / average loss size (e.g. 1.5)
+        capital: Account size
+        kelly_fraction: Multiplier on full Kelly (0.25 = quarter, 0.5 = half)
+    """
+    if not 0 < win_rate_pct < 100:
+        return {"error": "win_rate_pct must be in (0, 100)"}
+    if win_loss_ratio <= 0:
+        return {"error": "win_loss_ratio must be positive"}
+    if capital <= 0:
+        return {"error": "capital must be positive"}
+    if not 0 < kelly_fraction <= 1:
+        return {"error": "kelly_fraction must be in (0, 1]"}
+
+    w = win_rate_pct / 100
+    full_kelly = w - (1 - w) / win_loss_ratio
+    applied = full_kelly * kelly_fraction
+
+    if full_kelly <= 0:
+        return {
+            "win_rate_pct": win_rate_pct,
+            "win_loss_ratio": win_loss_ratio,
+            "full_kelly_pct": round(full_kelly * 100, 2),
+            "verdict": "NEGATIVE_EDGE",
+            "note": (
+                "Kelly is negative — this strategy has no edge. "
+                "Better to not trade than to trade smaller."
+            ),
+        }
+
+    bet_dollars = capital * applied if applied > 0 else 0
+
+    if full_kelly > 0.25:
+        risk_note = "Full Kelly > 25% — extreme variance, use fractional Kelly."
+    elif full_kelly > 0.10:
+        risk_note = "Full Kelly in normal range. Half Kelly recommended for stability."
+    else:
+        risk_note = "Modest edge — even Full Kelly is small. Fractional sizing is fine."
+
+    return {
+        "win_rate_pct": win_rate_pct,
+        "win_loss_ratio": win_loss_ratio,
+        "full_kelly_pct": round(full_kelly * 100, 2),
+        "applied_kelly_pct": round(applied * 100, 2),
+        "kelly_fraction_used": kelly_fraction,
+        "capital": capital,
+        "recommended_bet_dollars": round(bet_dollars, 2),
+        "verdict": "POSITIVE_EDGE",
+        "risk_note": risk_note,
+    }
+
+
+# ── Correlation matrix ────────────────────────────────────────────────────────
+
+def correlation_matrix(symbols: list[str], period: str = "6mo") -> dict:
+    """Pairwise correlation of daily returns. Diversification check.
+
+    > 0.7 — highly correlated (these positions move as one)
+    0.3–0.7 — moderately correlated
+    < 0.3 — meaningfully diversified
+    < 0  — hedged / negatively correlated
+    """
+    symbols = [s.upper().strip() for s in symbols if s and s.strip()][:8]
+    if len(symbols) < 2:
+        return {"error": "at least 2 symbols required"}
+
+    returns_by_symbol: dict[str, list[float]] = {}
+    fetch_errors: dict[str, str] = {}
+    for s in symbols:
+        try:
+            closes = _fetch_closes(s, period=period)
+            if len(closes) < 20:
+                fetch_errors[s] = f"insufficient history ({len(closes)} closes)"
+                continue
+            returns_by_symbol[s] = _returns(closes)
+        except (urllib.error.URLError, json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
+            fetch_errors[s] = f"{type(e).__name__}: {e}"
+
+    valid_symbols = list(returns_by_symbol.keys())
+    if len(valid_symbols) < 2:
+        return {"error": "could not fetch enough symbols", "fetch_errors": fetch_errors}
+
+    # Align lengths — trim each to the shortest series so indices match
+    min_len = min(len(r) for r in returns_by_symbol.values())
+    aligned = {s: r[-min_len:] for s, r in returns_by_symbol.items()}
+
+    matrix: dict[str, dict[str, float]] = {}
+    notable: list[dict] = []
+    for a in valid_symbols:
+        matrix[a] = {}
+        for b in valid_symbols:
+            if a == b:
+                matrix[a][b] = 1.0
+                continue
+            try:
+                corr = statistics.correlation(aligned[a], aligned[b])
+            except statistics.StatisticsError:
+                corr = 0.0
+            matrix[a][b] = round(corr, 3)
+
+    # Surface notable pairs (only one direction, not both A→B and B→A)
+    seen = set()
+    for a in valid_symbols:
+        for b in valid_symbols:
+            if a == b or (b, a) in seen:
+                continue
+            seen.add((a, b))
+            c = matrix[a][b]
+            if c > 0.7:
+                notable.append({"pair": f"{a}/{b}", "correlation": c, "note": "highly correlated — limited diversification"})
+            elif c < -0.3:
+                notable.append({"pair": f"{a}/{b}", "correlation": c, "note": "negatively correlated — natural hedge"})
+
+    return {
+        "symbols": valid_symbols,
+        "period": period,
+        "matrix": matrix,
+        "notable_pairs": notable,
+        "fetch_errors": fetch_errors,
+        "source": "Yahoo Finance",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ── Value at Risk ─────────────────────────────────────────────────────────────
+
+def value_at_risk(
+    symbol: str,
+    position_value: float,
+    period: str = "6mo",
+    confidence: float = 0.95,
+    horizon_days: int = 1,
+) -> dict:
+    """Historical + parametric VaR for a single position.
+
+    Historical VaR: empirical percentile of past returns (no normality assumption).
+    Parametric VaR: assumes returns ~ Normal(mean, std) — faster, riskier on fat tails.
+
+    Args:
+        symbol: Yahoo ticker
+        position_value: Current $ value of the position
+        period: History window for return distribution
+        confidence: 0.95 → 95% VaR, 0.99 → 99% VaR
+        horizon_days: Loss horizon (we scale by sqrt(t) for parametric)
+    """
+    if position_value <= 0:
+        return {"error": "position_value must be positive"}
+    if not 0.5 <= confidence < 1:
+        return {"error": "confidence must be in [0.5, 1)"}
+    if horizon_days < 1:
+        return {"error": "horizon_days must be >= 1"}
+
+    try:
+        closes = _fetch_closes(symbol, period=period)
+    except (urllib.error.URLError, json.JSONDecodeError, KeyError, IndexError, TypeError) as e:
+        return {"symbol": symbol.upper(), "error": f"{type(e).__name__}: {e}"}
+
+    if len(closes) < 30:
+        return {"symbol": symbol.upper(), "error": f"insufficient history ({len(closes)} closes)"}
+
+    returns = _returns(closes)
+    if not returns:
+        return {"symbol": symbol.upper(), "error": "no usable returns"}
+
+    sorted_returns = sorted(returns)
+    percentile_idx = max(0, int((1 - confidence) * len(sorted_returns)) - 1)
+    hist_var_return = sorted_returns[percentile_idx]
+    hist_var_dollars = position_value * (math.exp(hist_var_return) - 1)
+
+    # Parametric VaR (Cornish-Fisher / normal assumption — quick approximation)
+    mean = statistics.fmean(returns)
+    std = statistics.stdev(returns) if len(returns) > 1 else 0.0
+    # Inverse normal CDF approximation for common confidence levels
+    z = {0.90: -1.282, 0.95: -1.645, 0.975: -1.960, 0.99: -2.326}.get(
+        round(confidence, 3), -1.645
+    )
+    horizon_scale = math.sqrt(horizon_days)
+    param_var_return = mean * horizon_days + z * std * horizon_scale
+    param_var_dollars = position_value * (math.exp(param_var_return) - 1)
+
+    # Expected shortfall — mean loss beyond VaR (the "if it gets bad" number)
+    tail = sorted_returns[: percentile_idx + 1]
+    es_return = statistics.fmean(tail) if tail else hist_var_return
+    es_dollars = position_value * (math.exp(es_return) - 1)
+
+    return {
+        "symbol": symbol.upper(),
+        "position_value": position_value,
+        "period": period,
+        "confidence_level": confidence,
+        "horizon_days": horizon_days,
+        "historical_var": {
+            "loss_pct": round(hist_var_return * 100, 2),
+            "loss_dollars": round(hist_var_dollars, 2),
+            "interpretation": (
+                f"On a typical day at {confidence*100:.0f}% confidence, "
+                f"the worst loss observed historically was ${abs(round(hist_var_dollars, 2)):,.2f}"
+            ),
+        },
+        "parametric_var": {
+            "loss_pct": round(param_var_return * 100, 2),
+            "loss_dollars": round(param_var_dollars, 2),
+            "annualized_volatility_pct": round(std * math.sqrt(252) * 100, 2),
+        },
+        "expected_shortfall": {
+            "loss_pct": round(es_return * 100, 2),
+            "loss_dollars": round(es_dollars, 2),
+            "interpretation": "Average loss in the worst-case scenarios beyond VaR",
+        },
+        "sample_size": len(returns),
+        "source": "Yahoo Finance",
+    }

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -54,6 +54,19 @@ from tradingview_mcp.core.services.backtest_service import (
     compare_strategies as _compare_strategies,
     walk_forward_backtest,
 )
+from tradingview_mcp.core.services.fundamentals_service import (
+    get_fundamentals,
+    compare_peers as _compare_peers,
+    get_dividend_info,
+)
+from tradingview_mcp.core.services.risk_service import (
+    position_size as _position_size,
+    risk_reward as _risk_reward,
+    kelly_criterion as _kelly_criterion,
+    correlation_matrix as _correlation_matrix,
+    value_at_risk as _value_at_risk,
+)
+from tradingview_mcp.core.services.investment_thesis_service import generate_investment_thesis
 from tradingview_mcp.core.utils.validators import (
     sanitize_timeframe,
     sanitize_exchange,
@@ -600,6 +613,210 @@ def walk_forward_backtest_strategy(
     return walk_forward_backtest(
         symbol, strategy, period, initial_capital,
         commission_pct, slippage_pct, n_splits, train_ratio, interval,
+    )
+
+
+# ── Fundamental analysis tools ─────────────────────────────────────────────────
+
+@mcp.tool()
+def stock_fundamentals(symbol: str) -> dict:
+    """Full fundamental analysis: valuation, profitability, growth, balance sheet, dividend.
+
+    Pulls P/E, P/B, EPS, ROE, ROA, profit margins, revenue/earnings growth,
+    debt/equity, free cash flow, dividend yield, and analyst targets from
+    Yahoo Finance — then synthesises a fundamental verdict
+    (STRONG_FUNDAMENTAL_BUY / FUNDAMENTAL_BUY / HOLD / SELL / STRONG_SELL)
+    with bullish and bearish factor lists.
+
+    Use this for ANY equity question that's not purely technical — "Is AAPL
+    fairly valued?", "Is TSLA's growth slowing?", "How leveraged is META?".
+
+    Args:
+        symbol: Yahoo Finance ticker — AAPL, MSFT, TSLA, THYAO.IS, COMI.CA, 600519.SS, 2330.TW
+    """
+    return get_fundamentals(symbol)
+
+
+@mcp.tool()
+def compare_peers(symbols: list[str]) -> dict:
+    """Side-by-side fundamental comparison across up to 8 tickers.
+
+    Returns a row-per-symbol table of valuation/profitability/growth metrics
+    plus per-metric leaders (cheapest P/E, highest ROE, lowest leverage, etc.).
+    Useful for "is AAPL cheaper than its FAANG peers?" or "which BIST bank
+    has the best fundamentals right now?".
+
+    Args:
+        symbols: List of Yahoo tickers, e.g. ["AAPL", "MSFT", "NVDA", "GOOG"]
+                 BIST: ["GARAN.IS", "AKBNK.IS", "ISCTR.IS"]
+    """
+    if not symbols:
+        return {"error": "provide at least one symbol"}
+    return _compare_peers(symbols)
+
+
+@mcp.tool()
+def dividend_info(symbol: str) -> dict:
+    """Income-focused view: yield, payout ratio, ex-dividend date, sustainability flags.
+
+    For dividend investors who care about cash flow over capital appreciation.
+    Grades the income (LOW/STANDARD/HIGH/ULTRA_HIGH) and flags unsustainable
+    payouts (e.g. dividend exceeds free cash flow).
+
+    Args:
+        symbol: Yahoo Finance ticker — KO, JNJ, T, VZ, AAPL, etc.
+    """
+    return get_dividend_info(symbol)
+
+
+# ── Risk & position sizing tools ───────────────────────────────────────────────
+
+@mcp.tool()
+def position_sizing(
+    account_size: float,
+    risk_pct: float,
+    entry: float,
+    stop: float,
+) -> dict:
+    """Calculate how many units to buy given account, max-risk %, and stop-loss.
+
+    Implements the 1-2% rule: never risk more than X% of account on a single
+    trade. Output includes unit count, total position value, exposure %,
+    and warnings for over-concentration or unreasonable stop distances.
+
+    Args:
+        account_size: Total trading capital in dollars (e.g. 50000)
+        risk_pct: Max % of account to lose if stop hits (typically 0.5-2)
+        entry: Planned entry price
+        stop: Planned stop-loss price (below entry for long, above for short)
+    """
+    return _position_size(account_size, risk_pct, entry, stop)
+
+
+@mcp.tool()
+def risk_reward_calc(entry: float, stop: float, target: float) -> dict:
+    """R-multiple risk/reward analyzer for a planned trade.
+
+    Returns the reward/risk ratio (R-multiple), a grade (EXCELLENT 3R+ /
+    GOOD 2-3R / MARGINAL 1-2R / POOR <1R), and the breakeven win rate
+    needed. Below 1R the trade is a structural negative-edge bet that no
+    win rate can save.
+
+    Args:
+        entry: Entry price
+        stop: Stop-loss price
+        target: Take-profit / target price
+    """
+    return _risk_reward(entry, stop, target)
+
+
+@mcp.tool()
+def kelly_position_size(
+    win_rate_pct: float,
+    win_loss_ratio: float,
+    capital: float = 10000.0,
+    kelly_fraction: float = 0.5,
+) -> dict:
+    """Kelly Criterion optimal bet sizing based on historical win rate and avg win/loss.
+
+    Full Kelly is mathematically optimal but emotionally brutal (50%+ drawdowns).
+    Most pros use Half Kelly (default 0.5) or Quarter Kelly. Returns NEGATIVE_EDGE
+    verdict if Kelly is non-positive — meaning the strategy has no edge and you
+    shouldn't trade it at any size.
+
+    Args:
+        win_rate_pct: Historical win rate, e.g. 55 for 55%
+        win_loss_ratio: Average win size / average loss size (e.g. 1.5)
+        capital: Account size (default $10,000)
+        kelly_fraction: Multiplier on full Kelly — 0.25 quarter, 0.5 half (default), 1.0 full
+    """
+    return _kelly_criterion(win_rate_pct, win_loss_ratio, capital, kelly_fraction)
+
+
+@mcp.tool()
+def correlation_matrix(symbols: list[str], period: str = "6mo") -> dict:
+    """Pairwise correlation of daily returns across a portfolio.
+
+    Diversification check: > 0.7 means assets move as one (no real diversification),
+    < 0.3 means meaningfully diversified, < 0 means hedged. Flags notable pairs
+    that warrant rebalancing.
+
+    Args:
+        symbols: Up to 8 Yahoo tickers — ["AAPL", "MSFT", "TSLA", "BTC-USD", "GLD"]
+        period: '1mo' | '3mo' | '6mo' | '1y' | '2y' (default 6mo)
+    """
+    return _correlation_matrix(symbols, period)
+
+
+@mcp.tool()
+def value_at_risk_analysis(
+    symbol: str,
+    position_value: float,
+    period: str = "6mo",
+    confidence: float = 0.95,
+    horizon_days: int = 1,
+) -> dict:
+    """Value at Risk for a single position — historical, parametric, and expected shortfall.
+
+    Tells you the worst plausible loss on a position over a given horizon at a
+    given confidence level. Historical VaR uses the empirical return distribution
+    (no normality assumption), parametric assumes Normal returns. Expected
+    Shortfall (CVaR) gives the average loss when things go beyond VaR.
+
+    Args:
+        symbol: Yahoo ticker — AAPL, BTC-USD, SPY, ^GSPC
+        position_value: Current dollar value of the position
+        period: History window — '3mo', '6mo', '1y', '2y' (default 6mo)
+        confidence: 0.90, 0.95, 0.975, or 0.99 (default 0.95)
+        horizon_days: Forward-looking loss horizon in days (default 1)
+    """
+    return _value_at_risk(symbol, position_value, period, confidence, horizon_days)
+
+
+# ── Investment thesis (orchestration) ──────────────────────────────────────────
+
+@mcp.tool()
+def investment_thesis(
+    symbol: str,
+    exchange: str = "NASDAQ",
+    timeframe: str = "1D",
+    position_value: float = 0.0,
+    include_news: bool = True,
+    include_sentiment: bool = True,
+) -> dict:
+    """FULL investment-grade thesis: technical + fundamental + sentiment + news + macro + risk.
+
+    The flagship analyst tool. Synthesizes every dimension into:
+      - Bull case: bulleted reasons to be long
+      - Bear case: bulleted reasons to be short / avoid
+      - Catalysts: news + analyst targets that move the stock
+      - Risks: macro headwinds, VaR exposure (if position_value given)
+      - Price targets: analyst consensus + technical entry/stop/target
+      - Verdict: STRONG_BUY / BUY / HOLD / SELL / STRONG_SELL
+      - Conviction: HIGH (signals align) / MEDIUM (partial confluence) / LOW (mixed)
+
+    Use this when the user asks "should I buy X?" or "give me a full report on Y".
+    For pure technicals use combined_analysis or coin_analysis; for pure fundamentals
+    use stock_fundamentals. This tool is the everything-at-once view.
+
+    Args:
+        symbol: Asset symbol — AAPL, BTCUSDT, THYAO, COMI, 600519
+        exchange: Exchange — crypto: KUCOIN/BINANCE/MEXC; stocks: NASDAQ/NYSE/BIST/EGX/SSE/SZSE/TWSE
+        timeframe: Technical TF — 1D recommended for investing, 4h/1h for swing trades
+        position_value: Optional $ amount — if >0, adds VaR risk section sized to this
+        include_news: Pull RSS news headlines (slower; default True)
+        include_sentiment: Pull Reddit sentiment (slower; default True)
+    """
+    exchange = sanitize_exchange(exchange, "NASDAQ")
+    timeframe = sanitize_timeframe(timeframe, "1D")
+    pos_val = position_value if position_value and position_value > 0 else None
+    return generate_investment_thesis(
+        symbol=symbol,
+        exchange=exchange,
+        timeframe=timeframe,
+        position_value=pos_val,
+        include_news=include_news,
+        include_sentiment=include_sentiment,
     )
 
 


### PR DESCRIPTION
Adds three new service modules and wires them into the MCP server:

- fundamentals_service: stock_fundamentals, compare_peers, dividend_info
- risk_service: position_sizing, risk_reward_calc, kelly_position_size, correlation_matrix, value_at_risk_analysis
- investment_thesis_service: investment_thesis (full bull/bear synthesis combining technicals + fundamentals + sentiment + news + macro + VaR)

Also adds scripts/smoke_http.ps1 to verify the 9 tools register cleanly over streamable-http, and gitignores local .mcp.json configs.