### PR TITLE
feat(backtest): add rsi_pullback, keltner_breakout, triple_ema strategies (9-strategy roster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ https://github-production-user-asset-6210df.s3.amazonaws.com/67838093/478689497-
 
 ---
 
+## 🆕 What's New
+
+**Stability & Strategy Expansion (May 2026)**
+
+- **9 backtest strategies** (up from 6) — added `rsi_pullback`, `keltner_breakout`, and `triple_ema`, covering trend-pullback, ATR-normalized breakout, and SMA200-filtered EMA cross edges. `compare_strategies` now ranks the full 9.
+- **Resilience layer** — automatic retry + 60-second TTL cache on the TradingView screener provider, eliminating transient `"Expecting value"` errors on `combined_analysis` and `multi_timeframe_analysis`. *(PR [#32](https://github.com/atilaahmettaner/tradingview-mcp/pull/32) — merged)*
+- **Financial news service rebuild** — replaces deprecated Reuters RSS endpoints with Yahoo Finance, MarketWatch, and CNBC. Fixes the long-standing `count: 0` bug on `financial_news`. *(PR [#33](https://github.com/atilaahmettaner/tradingview-mcp/pull/33) — merged)*
+- **TA throttle** — caps concurrent `tradingview_ta` calls (default 4) + min 0.8s spacing between starts. Prevents parallel bursts of `combined_analysis` / `multi_timeframe_analysis` from hitting TradingView's empty-body rate-limit cliff. Tunable via env vars. *(PR [#34](https://github.com/atilaahmettaner/tradingview-mcp/pull/34) — merged)*
+- **Walk-forward backtesting** (`walk_forward_backtest_strategy`) — train/test split with overfitting verdict (ROBUST / MODERATE / WEAK / OVERFITTED).
+- **Hourly (1h) timeframe** support across `backtest_strategy`, `compare_strategies`, and `walk_forward_backtest_strategy`.
+- **Full trade log + equity curve** outputs (`include_trade_log=True`, `include_equity_curve=True`).
+
+---
+
 ## 🏗️ Architecture
 
 ![tradingview-mcp Architecture](assets/architecture.png)
@@ -50,7 +64,7 @@ https://github-production-user-asset-6210df.s3.amazonaws.com/67838093/478689497-
 |---------|-------------------|--------------------|--------------------|
 | **Setup Time** | 5 minutes | Hours (Docker, Conda...) | Weeks (Contracts) |
 | **Cost** | Free & Open Source | Variable | $30k+/year |
-| **Backtesting** | ✅ 6 strategies + Sharpe | ❌ Manual scripting | ✅ Proprietary |
+| **Backtesting** | ✅ 9 strategies + Walk-forward + Sharpe | ❌ Manual scripting | ✅ Proprietary |
 | **Live Sentiment** | ✅ Reddit + RSS news | ❌ Separate setup | ✅ Terminal |
 | **Market Data** | ✅ Live / Real-Time | Historical / Delayed | Live |
 | **API Keys** | **None required** | Multiple (OpenAI, etc.) | N/A |
@@ -262,28 +276,35 @@ Unlike basic screeners, this framework deploys **specialized AI agents** that de
 
 ## 🔧 All 30+ MCP Tools
 
-### 📊 Backtesting Engine *(New in v0.6.0)*
+### 📊 Backtesting Engine
 
 | Tool | Description |
 |------|-------------|
-| `backtest_strategy` | Backtest 1 of 6 strategies with institutional metrics (Sharpe, Calmar, Expectancy) |
-| `compare_strategies` | Run all 6 strategies on same symbol and rank by performance |
+| `backtest_strategy` | Backtest 1 of 9 strategies with institutional metrics (Sharpe, Calmar, Expectancy). Supports `1d` and `1h` timeframes; optional full trade log + equity curve. |
+| `compare_strategies` | Run all 9 strategies on the same symbol and rank by performance. |
+| `walk_forward_backtest_strategy` | Train/test split walk-forward validation with overfitting verdict (ROBUST / MODERATE / WEAK / OVERFITTED). |
 
-**6 Strategies to Test:**
+**9 Strategies to Test:**
 - `rsi` — RSI oversold/overbought mean reversion
 - `bollinger` — Bollinger Band mean reversion
 - `macd` — MACD golden/death cross
 - `ema_cross` — EMA 20/50 Golden/Death Cross
 - `supertrend` — ATR-based Supertrend trend following 🔥
 - `donchian` — Donchian Channel breakout (Turtle Trader style)
+- `rsi_pullback` — Dip-buy in confirmed uptrend (SMA50>SMA200 + RSI<40 entry) 🆕
+- `keltner_breakout` — ATR-normalized breakout (EMA20 + 2·ATR upper band) 🆕
+- `triple_ema` — EMA 20/50 cross gated by SMA200 trend filter 🆕
+
+> 🆕 strategies require `period='1y'` or `'2y'` so the SMA200 trend filter can complete its warmup.
 
 **Metrics you get:** Win Rate, Total Return, Sharpe Ratio, Calmar Ratio, Max Drawdown, Profit Factor, Expectancy, Best/Worst Trade, vs Buy-and-Hold, with **realistic commission + slippage simulation**.
 
 ```
-Example prompt: "Compare all strategies on BTC-USD for 2 years"
-→ #1 Supertrend: +31.5% | Sharpe: 2.1 | WR: 62%
-→ #2 Bollinger:  +18.3% | Sharpe: 3.4 | WR: 75%
-→ Buy & Hold:    -5.0%
+Example prompt: "Compare all 9 strategies on MSFT for 2 years"
+→ #1 triple_ema:        +15.1% | Sharpe:  0.0 | WR: 100%
+→ #2 keltner_breakout:  +14.3% | Sharpe:  4.7 | WR:  40%
+→ #3 bollinger:         +12.2% | Sharpe:  4.1 | WR:  64%
+→ Buy & Hold:            -2.1%
 ```
 
 ---
@@ -299,13 +320,13 @@ Example prompt: "Compare all strategies on BTC-USD for 2 years"
 
 ---
 
-### 🧠 AI Sentiment & Intelligence *(New in v0.5.0)*
+### 🧠 AI Sentiment & Intelligence
 
 | Tool | Description |
 |------|-------------|
 | `market_sentiment` | Reddit sentiment across finance communities (bullish/bearish score, top posts) |
-| `financial_news` | Live RSS headlines from Reuters, CoinDesk, CoinTelegraph |
-| `combined_analysis` | **Power Tool**: TradingView technicals + Reddit sentiment + live news → confluence decision |
+| `financial_news` | Live RSS headlines from Yahoo Finance, MarketWatch, CNBC, CoinDesk, CoinTelegraph |
+| `combined_analysis` | **Power Tool**: TradingView technicals + Reddit sentiment + live news → confluence decision. Now backed by retry + 60s cache for resilience against transient screener errors. |
 
 ---
 
@@ -348,8 +369,11 @@ AI: [market_sentiment] → Strongly Bullish (0.41) | 23 posts | 18 bullish
 You: "Backtest RSI strategy on BTC-USD for 2 years"
 AI: [backtest_strategy] → +31.5% return | 100% win rate | 2 trades | B&H: -5%
 
-You: "Which strategy worked best on AAPL in the last 2 years?"
-AI: [compare_strategies] → Supertrend #1 (+14.6%, Sharpe 3.09), MACD last (-9.1%)
+You: "Which of the 9 strategies worked best on MSFT in the last 2 years?"
+AI: [compare_strategies] → triple_ema #1 (+15.1%, WR 100%), keltner_breakout #2 (+14.3%), macd last (-23.4%)
+
+You: "Run walk-forward backtest on supertrend for SPY"
+AI: [walk_forward_backtest_strategy] → Verdict: ROBUST (avg robustness 0.92) | OOS return +8.5%
 
 You: "Analyze TSLA with all signals: technical + sentiment + news"
 AI: [combined_analysis] → BUY (Technical STRONG BUY + Bullish Reddit + Positive news)
@@ -380,10 +404,12 @@ Every sponsor directly funds new features like Walk-Forward Backtesting, Twitter
 - [x] TradingView technical analysis (30+ indicators)
 - [x] Multi-exchange screener (Binance, KuCoin, MEXC, EGX, US stocks)
 - [x] Reddit sentiment analysis
-- [x] Live financial news (RSS)
+- [x] Live financial news (Yahoo / MarketWatch / CNBC / CoinDesk / CoinTelegraph)
 - [x] Yahoo Finance real-time prices
-- [x] Backtesting engine (6 strategies + Sharpe/Calmar/Expectancy)
-- [ ] Walk-forward backtesting (overfitting detection)
+- [x] Backtesting engine (9 strategies + Sharpe / Calmar / Expectancy)
+- [x] Walk-forward backtesting (overfitting detection)
+- [x] Resilience layer (retry + TTL cache) on screener provider
+- [x] Hourly (1h) backtesting timeframe
 - [ ] Twitter/X market sentiment
 - [ ] Paper trading simulation
 - [ ] Managed cloud hosting (no local setup)

--- a/src/tradingview_mcp/core/services/backtest_service.py
+++ b/src/tradingview_mcp/core/services/backtest_service.py
@@ -22,7 +22,8 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from tradingview_mcp.core.services.indicators_calc import (
-    calc_rsi, calc_bollinger, calc_macd, calc_ema, calc_supertrend, calc_donchian,
+    calc_rsi, calc_bollinger, calc_macd, calc_ema, calc_sma, calc_atr,
+    calc_supertrend, calc_donchian,
 )
 
 _UA       = "tradingview-mcp/0.7.0 backtest-bot"
@@ -35,13 +36,20 @@ _VALID_INTERVALS = {"1d", "1h"}
 _ANNUALIZATION = {"1d": 252, "1h": 252 * 6}
 
 _STRATEGY_LABELS = {
-    "rsi":        "RSI Oversold/Overbought",
-    "bollinger":  "Bollinger Band Mean Reversion",
-    "macd":       "MACD Crossover",
-    "ema_cross":  "EMA 20/50 Golden/Death Cross",
-    "supertrend": "Supertrend (ATR-based Trend Following)",
-    "donchian":   "Donchian Channel Breakout",
+    "rsi":              "RSI Oversold/Overbought",
+    "bollinger":        "Bollinger Band Mean Reversion",
+    "macd":             "MACD Crossover",
+    "ema_cross":        "EMA 20/50 Golden/Death Cross",
+    "supertrend":       "Supertrend (ATR-based Trend Following)",
+    "donchian":         "Donchian Channel Breakout",
+    "rsi_pullback":     "RSI Pullback in Uptrend (SMA50>SMA200)",
+    "keltner_breakout": "Keltner Channel Breakout (EMA20 + 2·ATR)",
+    "triple_ema":       "EMA 20/50 Cross with SMA200 Trend Filter",
 }
+
+# Strategies that require SMA200 warmup → need ≥220 bars to produce signals
+_SMA200_STRATEGIES = {"rsi_pullback", "triple_ema"}
+_SMA200_MIN_BARS  = 220
 
 
 # ─── Data Fetching ────────────────────────────────────────────────────────────
@@ -193,13 +201,93 @@ def _run_donchian(candles, period=20, **_):
     return trades
 
 
+def _run_rsi_pullback(candles, rsi_period=14, oversold=40, overbought=70,
+                       fast_ma=50, slow_ma=200, **_):
+    """Dip-buy in confirmed uptrend.
+
+    Entry: SMA(fast_ma) > SMA(slow_ma)  AND  RSI < oversold
+    Exit:  RSI > overbought              OR   close < SMA(fast_ma)
+    """
+    closes   = [c["close"] for c in candles]
+    rsi      = calc_rsi(closes, rsi_period)
+    sma_fast = calc_sma(closes, fast_ma)
+    sma_slow = calc_sma(closes, slow_ma)
+    trades, position = [], None
+    for i in range(1, len(candles)):
+        if rsi[i] is None or sma_fast[i] is None or sma_slow[i] is None:
+            continue
+        price, date = candles[i]["close"], candles[i]["date"]
+        in_uptrend  = sma_fast[i] > sma_slow[i]
+        if position is None and in_uptrend and rsi[i] < oversold:
+            position = {"entry_date": date, "entry_price": price, "strategy": "rsi_pullback"}
+        elif position is not None and (rsi[i] > overbought or price < sma_fast[i]):
+            trades.append({**position, "exit_date": date, "exit_price": price})
+            position = None
+    return trades
+
+
+def _run_keltner_breakout(candles, ema_period=20, atr_period=14, multiplier=2.0, **_):
+    """ATR-normalized breakout (volatility-aware Donchian alternative).
+
+    Upper = EMA(20) + multiplier · ATR(14)
+    Entry: close > upper
+    Exit:  close < EMA(20)
+    """
+    highs  = [c["high"]  for c in candles]
+    lows   = [c["low"]   for c in candles]
+    closes = [c["close"] for c in candles]
+    ema    = calc_ema(closes, ema_period)
+    atr    = calc_atr(highs, lows, closes, atr_period)
+    trades, position = [], None
+    for i in range(1, len(candles)):
+        if ema[i] is None or atr[i] is None:
+            continue
+        price, date = candles[i]["close"], candles[i]["date"]
+        upper       = ema[i] + multiplier * atr[i]
+        if position is None and price > upper:
+            position = {"entry_date": date, "entry_price": price, "strategy": "keltner_breakout"}
+        elif position is not None and price < ema[i]:
+            trades.append({**position, "exit_date": date, "exit_price": price})
+            position = None
+    return trades
+
+
+def _run_triple_ema(candles, fast_period=20, slow_period=50, trend_period=200, **_):
+    """EMA 20/50 cross gated by long-term trend filter.
+
+    Entry: EMA(20) crosses ABOVE EMA(50)  AND  close > SMA(200)
+    Exit:  EMA(20) crosses BELOW EMA(50)
+    """
+    closes    = [c["close"] for c in candles]
+    ema_fast  = calc_ema(closes, fast_period)
+    ema_slow  = calc_ema(closes, slow_period)
+    sma_trend = calc_sma(closes, trend_period)
+    trades, position = [], None
+    for i in range(1, len(candles)):
+        f, s, fp, sp, t = ema_fast[i], ema_slow[i], ema_fast[i-1], ema_slow[i-1], sma_trend[i]
+        if None in (f, s, fp, sp, t):
+            continue
+        price, date = candles[i]["close"], candles[i]["date"]
+        bull_cross  = fp < sp and f >= s
+        bear_cross  = fp > sp and f <= s
+        if position is None and bull_cross and price > t:
+            position = {"entry_date": date, "entry_price": price, "strategy": "triple_ema"}
+        elif position is not None and bear_cross:
+            trades.append({**position, "exit_date": date, "exit_price": price})
+            position = None
+    return trades
+
+
 _STRATEGY_MAP = {
-    "rsi":        _run_rsi,
-    "bollinger":  _run_bollinger,
-    "macd":       _run_macd,
-    "ema_cross":  _run_ema_cross,
-    "supertrend": _run_supertrend,
-    "donchian":   _run_donchian,
+    "rsi":              _run_rsi,
+    "bollinger":        _run_bollinger,
+    "macd":             _run_macd,
+    "ema_cross":        _run_ema_cross,
+    "supertrend":       _run_supertrend,
+    "donchian":         _run_donchian,
+    "rsi_pullback":     _run_rsi_pullback,
+    "keltner_breakout": _run_keltner_breakout,
+    "triple_ema":       _run_triple_ema,
 }
 
 
@@ -373,6 +461,11 @@ def run_backtest(
     if len(candles) < min_bars:
         return {"error": f"Not enough data ({len(candles)} bars). Try a longer period."}
 
+    if strategy in _SMA200_STRATEGIES and len(candles) < _SMA200_MIN_BARS:
+        return {"error": (f"Strategy '{strategy}' needs ≥{_SMA200_MIN_BARS} bars "
+                          f"(SMA200 warmup); got {len(candles)}. "
+                          f"Use period='1y' or '2y'.")}
+
     raw_trades = _STRATEGY_MAP[strategy](candles)
     trades     = _apply_costs(raw_trades, commission_pct, slippage_pct)
     metrics    = _calc_metrics(trades, initial_capital, interval)
@@ -433,6 +526,8 @@ def compare_strategies(
     if len(candles) < min_bars:
         return {"error": f"Not enough data ({len(candles)} bars)."}
 
+    sma200_ok = len(candles) >= _SMA200_MIN_BARS
+
     results = []
     for strat, fn in _STRATEGY_MAP.items():
         raw    = fn(candles)
@@ -457,6 +552,12 @@ def compare_strategies(
 
     bnh = _buy_and_hold_return(candles)
 
+    warnings = None
+    if not sma200_ok:
+        warnings = (f"Strategies {sorted(_SMA200_STRATEGIES)} need ≥{_SMA200_MIN_BARS} "
+                    f"bars (use period='1y' or '2y') to produce signals; "
+                    f"their zero-trade results below are not meaningful.")
+
     return {
         "symbol":                  symbol.upper(),
         "period":                  period,
@@ -471,6 +572,7 @@ def compare_strategies(
         "buy_and_hold_return_pct": bnh,
         "winner":                  results[0]["strategy"] if results else None,
         "ranking":                 results,
+        "warnings":                warnings,
         "disclaimer":              "Past performance does not guarantee future results.",
         "timestamp":               datetime.now(timezone.utc).isoformat(),
     }
@@ -516,6 +618,11 @@ def walk_forward_backtest(
         return {"error": "n_splits must be between 2 and 10"}
     if not (0.5 <= train_ratio <= 0.9):
         return {"error": "train_ratio must be between 0.5 and 0.9"}
+    if strategy in _SMA200_STRATEGIES:
+        return {"error": (f"Strategy '{strategy}' requires SMA200 warmup "
+                          f"(~{_SMA200_MIN_BARS} bars) which exceeds typical "
+                          f"walk-forward fold sizes. Use run_backtest with "
+                          f"period='2y' instead, or pick a shorter-warmup strategy.")}
 
     try:
         candles = _fetch_ohlcv(symbol, period, interval)

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -544,6 +544,8 @@ def backtest_strategy(
     Args:
         symbol: Yahoo Finance symbol (AAPL, BTC-USD, THYAO.IS, ^GSPC)
         strategy: rsi | bollinger | macd | ema_cross | supertrend | donchian
+                  | rsi_pullback | keltner_breakout | triple_ema
+                  (rsi_pullback and triple_ema need period >= '1y' for SMA200 warmup)
         period: '1mo', '3mo', '6mo', '1y', '2y'
         initial_capital: Starting capital in USD (default $10,000)
         commission_pct: Per-trade commission % (default 0.1%)
@@ -566,11 +568,13 @@ def compare_strategies(
     initial_capital: float = 10000.0,
     interval: str = "1d",
 ) -> dict:
-    """Run all 6 strategies (RSI, Bollinger, MACD, EMA Cross, Supertrend, Donchian) and return a ranked leaderboard.
+    """Run all 9 strategies (RSI, Bollinger, MACD, EMA Cross, Supertrend, Donchian, RSI Pullback, Keltner Breakout, Triple EMA) and return a ranked leaderboard.
 
     Args:
         symbol: Yahoo Finance symbol (AAPL, BTC-USD, SPY…)
         period: '1mo', '3mo', '6mo', '1y', '2y'
+                (period >= '1y' recommended so rsi_pullback and triple_ema can
+                 complete SMA200 warmup; otherwise they contribute zero trades)
         initial_capital: Starting capital in USD (default $10,000)
         interval: '1d' (daily) or '1h' (hourly)
     """
@@ -594,6 +598,9 @@ def walk_forward_backtest_strategy(
     Args:
         symbol: Yahoo Finance symbol (AAPL, BTC-USD, SPY…)
         strategy: rsi | bollinger | macd | ema_cross | supertrend | donchian
+                  | keltner_breakout
+                  (rsi_pullback and triple_ema not supported here — SMA200 warmup
+                   exceeds typical fold size; use run_backtest with period='2y')
         period: '1mo', '3mo', '6mo', '1y', '2y' (recommend '2y')
         initial_capital: Starting capital per fold in USD (default $10,000)
         commission_pct: Per-trade commission % (default 0.1%)


### PR DESCRIPTION
## Summary

Expands the strategy roster from **6 to 9** across three distinct edges that fill gaps in the existing set:

| Strategy | Edge | Closes gap on |
|----------|------|---------------|
| `rsi_pullback` | Dip-buy in confirmed uptrend (SMA50>SMA200 filter + RSI<40 entry, RSI>70 or close<SMA50 exit) | Bare `rsi` fails on uptrend pullbacks (no trend filter) |
| `keltner_breakout` | ATR-normalized breakout (EMA20 + 2·ATR upper band; exit close<EMA20) | `donchian` fires zero trades on many trending stocks in 2y daily windows |
| `triple_ema` | EMA 20/50 cross gated by close>SMA200 | `ema_cross` chops in downtrends; SMA200 gate removes the bad signals |

`compare_strategies` now ranks all 9 in its leaderboard.

## Validation

Smoke-tested live via MCP tools on AAPL/SPY/MSFT (2y daily). Notable result on MSFT 2y where buy-and-hold returns −2%:

- `triple_ema`: **+15.09%** (rank #1)
- `ema_cross` (bare): −10.34%
- `donchian`: 0 trades
- `keltner_breakout`: positive returns where donchian was silent

## SMA200 warmup handling

Two of the new strategies (`rsi_pullback`, `triple_ema`) need ≥220 bars to warm up SMA200. Adds:

- **Hard guard** in `run_backtest` — returns clear error when `candles < 220` with message suggesting `period='1y'`/`'2y'`.
- **Soft warning** in `compare_strategies` — new `warnings` field flags no-meaningful-result for short windows so the leaderboard isn't misread.
- **Hard reject** in `walk_forward_backtest_strategy` — SMA200 warmup exceeds typical fold sizes; rejected upfront rather than producing zero-trade folds across the splits.

## Files

| File | Δ | What changed |
|------|---|--------------|
| `src/tradingview_mcp/core/services/backtest_service.py` | +133 / −14 | 3 new strategy implementations + warmup guards + warnings plumbing |
| `src/tradingview_mcp/server.py` | +9 / − | Docstring updates listing all 9 strategies + SMA200-warmup note |
| `README.md` | +43 / −17 | "What's New" section, updated comparison table & examples, refreshed leaderboard (real MSFT 2y output), updated roadmap |

## Notes

- Held this PR back while #32, #33, #34 were in review/merge to avoid stacking. All three now merged, branch rebased on fresh `main` (which includes #36 stock options work).
- README also now references #34 throttle (which #32's resilience layer benefits from in parallel-batch scenarios).