### PR TITLE
feat(errors): structured error envelope + batch-failure sentinel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ test_bitget.py
 test_refactor.py
 test_*.py
 !src/**/test_*.py
+!tests/**/test_*.py
 
 # Internal strategy docs — not for public repo
 LAUNCH_STRATEGY.md

--- a/README.md
+++ b/README.md
@@ -155,6 +155,36 @@ After the install finishes, start Claude Desktop with the normal config and the 
 
 ---
 
+## ⚠️ Error Envelope Format
+
+Tools that have adopted the structured error format return either their normal payload **or** an error envelope:
+
+```json
+{"error": {"code": "ALL_BATCHES_FAILED", "message": "All 5 batches failed; first error: JSONDecodeError(...)", "batches_attempted": 5, "batches_failed": 5, "first_error": "..."}}
+```
+
+**Why:** the previous `[]` / `{"error": "Analysis failed: ..."}` strings made it impossible to distinguish "no matches today" from "upstream rate-limit cliff." The new envelope is programmatically branchable by `code`.
+
+**Currently adopted by:** `top_gainers`, `top_losers`, `rating_filter`, `volume_breakout_scanner`, `smart_volume_scanner`. More tools will follow in subsequent PRs.
+
+**Detecting an error:**
+
+```python
+result = volume_breakout_scanner(exchange="KUCOIN")
+if isinstance(result, dict) and "error" in result:
+    code = result["error"]["code"]
+    if code == "ALL_BATCHES_FAILED":
+        # Wait + retry, raise alert, fall back to single-batch call, etc.
+        ...
+else:
+    for row in result:
+        ...
+```
+
+Stable codes are defined in [`core/errors.py`](src/tradingview_mcp/core/errors.py).
+
+---
+
 ## 📱 Use via Telegram, WhatsApp & More (OpenClaw)
 
 Connect this server to **Telegram, WhatsApp, Discord** and 20+ messaging platforms using [OpenClaw](https://openclaw.ai) — a self-hosted AI gateway. **Tested & verified on Hetzner VPS (Ubuntu 24.04).**

--- a/src/tradingview_mcp/core/errors.py
+++ b/src/tradingview_mcp/core/errors.py
@@ -1,0 +1,120 @@
+"""
+Structured error envelope and exception types for tradingview-mcp.
+
+All recoverable failures return a typed error envelope:
+
+    {"error": {"code": "<CODE>", "message": "<human-readable>", **extras}}
+
+Use :func:`make_error` to construct envelopes and :func:`is_error` to check
+them. Service layers may also raise typed exceptions (e.g.
+:class:`BatchExecutionError`) which the MCP tool wrapper layer converts to the
+same envelope shape so MCP clients see a uniform error API.
+
+Migration notes
+---------------
+- Tools that adopt this format return ``dict`` (the envelope) on error and
+  their normal type on success — the static return type becomes a union.
+- Callers must check ``isinstance(result, dict) and "error" in result``
+  instead of substring-matching previous ``{"error": "Analysis failed: ..."}``
+  strings.
+- Adoption is opt-in per tool; see PR notes for the current opt-in set.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Union
+
+
+class ErrorCode(str, Enum):
+    """Stable string codes for programmatic branching by MCP clients.
+
+    Values are plain strings so they survive JSON serialization without
+    extra encoding, and so they can be compared against literals like
+    ``code == "ALL_BATCHES_FAILED"`` from any language.
+    """
+
+    # Input / validation
+    SYMBOL_NOT_FOUND = "SYMBOL_NOT_FOUND"
+    INVALID_EXCHANGE = "INVALID_EXCHANGE"
+    INVALID_TIMEFRAME = "INVALID_TIMEFRAME"
+    INVALID_PARAMETER = "INVALID_PARAMETER"
+
+    # Upstream (TradingView / Yahoo / RSS feeds)
+    UPSTREAM_RATE_LIMIT = "UPSTREAM_RATE_LIMIT"
+    UPSTREAM_TIMEOUT = "UPSTREAM_TIMEOUT"
+    UPSTREAM_ERROR = "UPSTREAM_ERROR"
+    ALL_BATCHES_FAILED = "ALL_BATCHES_FAILED"
+
+    # Data
+    NO_DATA = "NO_DATA"
+    PARTIAL_DATA = "PARTIAL_DATA"
+
+    # Environment
+    DEPENDENCY_MISSING = "DEPENDENCY_MISSING"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+def make_error(code: Union[ErrorCode, str], message: str, **extra: Any) -> dict[str, Any]:
+    """Construct a structured error envelope.
+
+    Args:
+        code: An :class:`ErrorCode` value or its raw string form. Accepting
+            plain strings keeps the helper usable from code that doesn't want
+            to import the enum (and from external contributions adopting the
+            envelope shape).
+        message: Human-readable description suitable for showing to a user.
+        **extra: Additional structured fields — e.g. ``retry_after_s=30``,
+            ``batches_attempted=5``, ``first_error="..."``, ``symbol="AAPL"``.
+
+    Returns:
+        ``{"error": {"code": ..., "message": ..., **extra}}``
+    """
+    code_str = code.value if isinstance(code, ErrorCode) else str(code)
+    err: dict[str, Any] = {"code": code_str, "message": message}
+    if extra:
+        err.update(extra)
+    return {"error": err}
+
+
+def is_error(payload: Any) -> bool:
+    """True if *payload* is an error envelope produced by :func:`make_error`.
+
+    Checks both the outer ``"error"`` key and the inner ``"code"`` to avoid
+    false positives against legacy string-error payloads (which had
+    ``payload["error"]`` as a string, not a dict).
+    """
+    return (
+        isinstance(payload, dict)
+        and isinstance(payload.get("error"), dict)
+        and "code" in payload["error"]
+    )
+
+
+class BatchExecutionError(Exception):
+    """Raised by batched scanners when every batch failed.
+
+    The service layer raises this so the MCP tool wrapper at the boundary
+    can convert it to an :func:`make_error` envelope with full context.
+    Callers must not swallow it silently — that defeats the whole point of
+    the sentinel.
+
+    Attributes:
+        batches_attempted: How many batches were issued to upstream.
+        batches_failed: How many of those failed
+            (equals ``batches_attempted`` whenever this is raised).
+        first_error: ``repr()`` of the first exception observed across the
+            batch loop, kept verbatim for debugging.
+    """
+
+    def __init__(
+        self,
+        batches_attempted: int,
+        batches_failed: int,
+        first_error: str,
+    ) -> None:
+        super().__init__(
+            f"All {batches_attempted} batches failed; first error: {first_error}"
+        )
+        self.batches_attempted = batches_attempted
+        self.batches_failed = batches_failed
+        self.first_error = first_error

--- a/src/tradingview_mcp/core/services/scanner_service.py
+++ b/src/tradingview_mcp/core/services/scanner_service.py
@@ -3,11 +3,18 @@ Scanner Service — volume breakout and technical pattern scanning logic.
 
 All functions take validated parameters and return plain dicts / lists.
 They have zero dependency on the MCP layer and are independently testable.
+
+Batched scanners raise :class:`BatchExecutionError` when 100% of upstream
+batches fail, so the tool wrapper at the MCP boundary can convert that into a
+structured error envelope. Returning ``[]`` on total failure (the historical
+behavior) hid rate-limit cliffs as "no results today".
 """
 from __future__ import annotations
 
-from typing import List
+import sys
+from typing import List, Optional
 
+from tradingview_mcp.core.errors import BatchExecutionError
 from tradingview_mcp.core.services.coinlist import load_symbols
 from tradingview_mcp.core.services.indicators import compute_metrics
 from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, is_stock_exchange
@@ -53,11 +60,27 @@ def volume_breakout_scan(
     volume_breakouts: List[dict] = []
     batch_size = 100
 
+    batches_attempted = 0
+    batches_failed = 0
+    first_error: Optional[str] = None
+
     for i in range(0, min(len(symbols), 500), batch_size):
         batch = symbols[i : i + batch_size]
+        batches_attempted += 1
         try:
             analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=batch)
-        except Exception:
+        except Exception as exc:
+            batches_failed += 1
+            if first_error is None:
+                first_error = repr(exc)
+            try:
+                print(
+                    f"[tradingview_mcp] volume_breakout_scan batch "
+                    f"{i // batch_size + 1} failed: {exc!r}",
+                    file=sys.stderr,
+                )
+            except Exception:
+                pass
             continue
 
         for symbol, data in analysis.items():
@@ -107,6 +130,16 @@ def volume_breakout_scan(
                     )
             except Exception:
                 continue
+
+    # Sentinel: every batch failed means the upstream is unavailable
+    # (rate limit, blocked, outage). Raise so the tool wrapper can return a
+    # typed error envelope instead of an indistinguishable empty list.
+    if batches_attempted > 0 and batches_failed == batches_attempted:
+        raise BatchExecutionError(
+            batches_attempted=batches_attempted,
+            batches_failed=batches_failed,
+            first_error=first_error or "unknown",
+        )
 
     volume_breakouts.sort(
         key=lambda x: (x["volume_strength"], abs(x["changePercent"])),

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -3,11 +3,18 @@ Screener Service — low-level data-fetching helpers for TradingView analysis.
 
 All functions call TradingView APIs and return normalised Row / MultiRow lists.
 They are intentionally free of MCP concerns so they can be unit-tested directly.
+
+Batched scanners (``fetch_trending_analysis``) raise
+:class:`~tradingview_mcp.core.errors.BatchExecutionError` when every upstream
+batch fails. The MCP tool wrapper layer converts that to a structured error
+envelope so callers can distinguish "no matches today" from "upstream cliff".
 """
 from __future__ import annotations
 
+import sys
 from typing import Any, List, Optional
 
+from tradingview_mcp.core.errors import BatchExecutionError
 from tradingview_mcp.core.types import (
     IndicatorMap, MultiRow, Row,
     percent_change, tf_to_tv_resolution,
@@ -137,11 +144,27 @@ def fetch_trending_analysis(
     batch_size = 200
     all_coins: List[Row] = []
 
+    batches_attempted = 0
+    batches_failed = 0
+    first_error: Optional[str] = None
+
     for i in range(0, len(symbols), batch_size):
         batch = symbols[i : i + batch_size]
+        batches_attempted += 1
         try:
             analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=batch)
-        except Exception:
+        except Exception as exc:
+            batches_failed += 1
+            if first_error is None:
+                first_error = repr(exc)
+            try:
+                print(
+                    f"[tradingview_mcp] fetch_trending_analysis batch "
+                    f"{i // batch_size + 1} failed: {exc!r}",
+                    file=sys.stderr,
+                )
+            except Exception:
+                pass
             continue
 
         for key, value in analysis.items():
@@ -174,6 +197,16 @@ def fetch_trending_analysis(
                 )
             except (TypeError, ZeroDivisionError, KeyError):
                 continue
+
+    # Sentinel: every batch failed means the upstream is unavailable.
+    # Raise so the tool wrapper returns a typed error envelope instead of
+    # an indistinguishable empty list.
+    if batches_attempted > 0 and batches_failed == batches_attempted:
+        raise BatchExecutionError(
+            batches_attempted=batches_attempted,
+            batches_failed=batches_failed,
+            first_error=first_error or "unknown",
+        )
 
     all_coins.sort(key=lambda x: x["changePercent"], reverse=True)
     return all_coins[:limit]

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -65,6 +65,11 @@ from tradingview_mcp.core.utils.validators import (
     normalize_tradingview_symbol,
     normalize_yahoo_symbol,
 )
+from tradingview_mcp.core.errors import (
+    BatchExecutionError,
+    ErrorCode,
+    make_error,
+)
 
 try:
     import tradingview_screener  # noqa: F401
@@ -90,28 +95,52 @@ mcp = FastMCP(
 # ── Screener tools ─────────────────────────────────────────────────────────────
 
 @mcp.tool()
-def top_gainers(exchange: str = "KUCOIN", timeframe: str = "15m", limit: int = 25) -> list[dict]:
+def top_gainers(exchange: str = "KUCOIN", timeframe: str = "15m", limit: int = 25) -> list[dict] | dict:
     """Return top gainers for an exchange and timeframe using Bollinger Band analysis.
 
     Args:
         exchange: Exchange name — crypto: KUCOIN, BINANCE, BYBIT, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, BURSA, HKEX, SSE, SZSE, TWSE, TPEX
         timeframe: One of 5m, 15m, 1h, 4h, 1D, 1W, 1M
         limit: Number of rows to return (max 50)
+
+    Returns:
+        list[dict] on success. On total upstream failure returns a structured
+        error envelope: ``{"error": {"code": "ALL_BATCHES_FAILED", ...}}``.
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     timeframe = sanitize_timeframe(timeframe, "15m")
     limit = max(1, min(limit, 50))
-    rows = fetch_trending_analysis(exchange, timeframe=timeframe, limit=limit)
+    try:
+        rows = fetch_trending_analysis(exchange, timeframe=timeframe, limit=limit)
+    except BatchExecutionError as e:
+        return make_error(
+            ErrorCode.ALL_BATCHES_FAILED, str(e),
+            batches_attempted=e.batches_attempted,
+            batches_failed=e.batches_failed,
+            first_error=e.first_error,
+        )
     return [{"symbol": r["symbol"], "changePercent": r["changePercent"], "indicators": dict(r["indicators"])} for r in rows]
 
 
 @mcp.tool()
-def top_losers(exchange: str = "KUCOIN", timeframe: str = "15m", limit: int = 25) -> list[dict]:
-    """Return top losers for an exchange and timeframe. Supports crypto (KUCOIN, BINANCE, MEXC) and stocks (EGX, BIST, NASDAQ)."""
+def top_losers(exchange: str = "KUCOIN", timeframe: str = "15m", limit: int = 25) -> list[dict] | dict:
+    """Return top losers for an exchange and timeframe. Supports crypto (KUCOIN, BINANCE, MEXC) and stocks (EGX, BIST, NASDAQ).
+
+    Returns ``list[dict]`` on success, or an error envelope on total upstream
+    failure (``{"error": {"code": "ALL_BATCHES_FAILED", ...}}``).
+    """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     timeframe = sanitize_timeframe(timeframe, "15m")
     limit = max(1, min(limit, 50))
-    rows = fetch_trending_analysis(exchange, timeframe=timeframe, limit=limit)
+    try:
+        rows = fetch_trending_analysis(exchange, timeframe=timeframe, limit=limit)
+    except BatchExecutionError as e:
+        return make_error(
+            ErrorCode.ALL_BATCHES_FAILED, str(e),
+            batches_attempted=e.batches_attempted,
+            batches_failed=e.batches_failed,
+            first_error=e.first_error,
+        )
     rows.sort(key=lambda x: x["changePercent"])
     return [{"symbol": r["symbol"], "changePercent": r["changePercent"], "indicators": dict(r["indicators"])} for r in rows[:limit]]
 
@@ -134,7 +163,7 @@ def bollinger_scan(exchange: str = "KUCOIN", timeframe: str = "4h", bbw_threshol
 
 
 @mcp.tool()
-def rating_filter(exchange: str = "KUCOIN", timeframe: str = "5m", rating: int = 2, limit: int = 25) -> list[dict]:
+def rating_filter(exchange: str = "KUCOIN", timeframe: str = "5m", rating: int = 2, limit: int = 25) -> list[dict] | dict:
     """Filter coins by Bollinger Band rating.
 
     Args:
@@ -142,12 +171,23 @@ def rating_filter(exchange: str = "KUCOIN", timeframe: str = "5m", rating: int =
         timeframe: One of 5m, 15m, 1h, 4h, 1D, 1W, 1M
         rating: BB rating (-3 to +3): -3=Strong Sell, -2=Sell, -1=Weak Sell, 1=Weak Buy, 2=Buy, 3=Strong Buy
         limit: Number of rows to return (max 50)
+
+    Returns ``list[dict]`` on success, or an error envelope on total upstream
+    failure (``{"error": {"code": "ALL_BATCHES_FAILED", ...}}``).
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     timeframe = sanitize_timeframe(timeframe, "5m")
     rating = max(-3, min(3, rating))
     limit = max(1, min(limit, 50))
-    rows = fetch_trending_analysis(exchange, timeframe=timeframe, filter_type="rating", rating_filter=rating, limit=limit)
+    try:
+        rows = fetch_trending_analysis(exchange, timeframe=timeframe, filter_type="rating", rating_filter=rating, limit=limit)
+    except BatchExecutionError as e:
+        return make_error(
+            ErrorCode.ALL_BATCHES_FAILED, str(e),
+            batches_attempted=e.batches_attempted,
+            batches_failed=e.batches_failed,
+            first_error=e.first_error,
+        )
     return [{"symbol": r["symbol"], "changePercent": r["changePercent"], "indicators": dict(r["indicators"])} for r in rows]
 
 
@@ -254,7 +294,7 @@ def volume_breakout_scanner(
     volume_multiplier: float = 2.0,
     price_change_min: float = 3.0,
     limit: int = 25,
-) -> list[dict]:
+) -> list[dict] | dict:
     """Detect coins with volume breakout + price breakout.
 
     Args:
@@ -263,13 +303,26 @@ def volume_breakout_scanner(
         volume_multiplier: How many times the volume should be above normal level (default 2.0)
         price_change_min: Minimum price change percentage (default 3.0)
         limit: Number of rows to return (max 50)
+
+    Returns ``list[dict]`` on success, or an error envelope on total upstream
+    failure (``{"error": {"code": "ALL_BATCHES_FAILED", ...}}``). The empty
+    list now strictly means "no matches today"; rate-limit cliffs surface
+    explicitly.
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     timeframe = sanitize_timeframe(timeframe, "15m")
     volume_multiplier = max(1.5, min(10.0, volume_multiplier))
     price_change_min = max(1.0, min(20.0, price_change_min))
     limit = max(1, min(limit, 50))
-    return volume_breakout_scan(exchange, timeframe, volume_multiplier, price_change_min, limit)
+    try:
+        return volume_breakout_scan(exchange, timeframe, volume_multiplier, price_change_min, limit)
+    except BatchExecutionError as e:
+        return make_error(
+            ErrorCode.ALL_BATCHES_FAILED, str(e),
+            batches_attempted=e.batches_attempted,
+            batches_failed=e.batches_failed,
+            first_error=e.first_error,
+        )
 
 
 @mcp.tool()
@@ -293,7 +346,7 @@ def smart_volume_scanner(
     min_price_change: float = 2.0,
     rsi_range: str = "any",
     limit: int = 20,
-) -> list[dict]:
+) -> list[dict] | dict:
     """Smart volume + technical analysis combination scanner.
 
     Args:
@@ -302,12 +355,24 @@ def smart_volume_scanner(
         min_price_change: Minimum price change percentage (default 2.0)
         rsi_range: "oversold" (<30), "overbought" (>70), "neutral" (30-70), "any"
         limit: Number of results (max 30)
+
+    Returns ``list[dict]`` on success, or an error envelope on total upstream
+    failure (``{"error": {"code": "ALL_BATCHES_FAILED", ...}}``) — inherited
+    from the inner ``volume_breakout_scan`` call.
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
     min_volume_ratio = max(1.2, min(10.0, min_volume_ratio))
     min_price_change = max(0.5, min(20.0, min_price_change))
     limit = max(1, min(limit, 30))
-    return smart_volume_scan(exchange, min_volume_ratio, min_price_change, rsi_range, limit)
+    try:
+        return smart_volume_scan(exchange, min_volume_ratio, min_price_change, rsi_range, limit)
+    except BatchExecutionError as e:
+        return make_error(
+            ErrorCode.ALL_BATCHES_FAILED, str(e),
+            batches_attempted=e.batches_attempted,
+            batches_failed=e.batches_failed,
+            first_error=e.first_error,
+        )
 
 
 # ── Multi-agent analysis ───────────────────────────────────────────────────────

--- a/tests/unit/services/test_batch_sentinel.py
+++ b/tests/unit/services/test_batch_sentinel.py
@@ -1,0 +1,185 @@
+"""Batch sentinel integration tests.
+
+When 100% of upstream batches fail, batched scanners must raise
+``BatchExecutionError`` instead of silently returning ``[]``. The empty list
+used to hide rate-limit cliffs as "no matches today"; the sentinel makes the
+failure mode explicit so tool wrappers can convert it to a structured error
+envelope at the MCP boundary.
+"""
+from __future__ import annotations
+
+from json import JSONDecodeError
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from tradingview_mcp.core.errors import BatchExecutionError
+
+
+# --- Helpers ----------------------------------------------------------------
+
+class _FakeAnalysis(SimpleNamespace):
+    """Minimal stand-in for ``tradingview_ta`` analysis objects.
+
+    Only exposes the ``indicators`` attribute the scanners read. Values are
+    intentionally chosen so the per-symbol filter logic passes/fails as needed.
+    """
+
+
+def _good_indicators() -> dict[str, Any]:
+    """Indicators that comfortably clear ``volume_breakout_scan`` defaults
+    (volume_multiplier=2.0, price_change_min=3.0)."""
+    return {
+        "volume": 10_000.0,
+        "close": 110.0,
+        "open": 100.0,        # +10% bar — well above the 3.0% threshold
+        "volume.SMA20": 1_000.0,  # 10x avg — well above the 2x threshold
+        "RSI": 55.0,
+        "BB.upper": 115.0,
+        "BB.lower": 95.0,
+    }
+
+
+def _make_batch_response(symbols: list[str]) -> dict:
+    """Map ``EXCHANGE:SYMBOL`` -> fake analysis object."""
+    return {s: _FakeAnalysis(indicators=_good_indicators()) for s in symbols}
+
+
+# --- Tests for volume_breakout_scan -----------------------------------------
+
+class TestVolumeBreakoutScanSentinel:
+    def test_all_batches_fail_raises(self):
+        """When every batch raises, the sentinel must fire."""
+        from tradingview_mcp.core.services import scanner_service
+
+        def always_fail(*_args, **_kwargs):
+            # Mirrors the real upstream "empty body" failure mode.
+            raise JSONDecodeError("Expecting value", "", 0)
+
+        with patch.object(scanner_service, "get_multiple_analysis", side_effect=always_fail), \
+             patch.object(scanner_service, "load_symbols", return_value=[f"SYM{i}" for i in range(250)]):
+            with pytest.raises(BatchExecutionError) as exc_info:
+                scanner_service.volume_breakout_scan(
+                    exchange="KUCOIN",
+                    timeframe="15m",
+                )
+
+        # batch_size=100 over 250 symbols => 3 batches attempted (100, 100, 50)
+        assert exc_info.value.batches_attempted == 3
+        assert exc_info.value.batches_failed == 3
+        assert "Expecting value" in exc_info.value.first_error
+
+    def test_all_succeed_returns_list_no_raise(self):
+        """Happy path: every batch returns data, no sentinel."""
+        from tradingview_mcp.core.services import scanner_service
+
+        def all_good(*, screener, interval, symbols):
+            return _make_batch_response(symbols)
+
+        with patch.object(scanner_service, "get_multiple_analysis", side_effect=all_good), \
+             patch.object(scanner_service, "load_symbols", return_value=[f"SYM{i}" for i in range(150)]):
+            result = scanner_service.volume_breakout_scan(
+                exchange="KUCOIN",
+                timeframe="15m",
+                limit=10,
+            )
+
+        assert isinstance(result, list)
+        assert len(result) <= 10
+        assert len(result) > 0  # Our fake indicators trip the filter
+        for row in result:
+            assert "symbol" in row
+            assert "breakout_type" in row
+
+    def test_partial_failure_no_raise(self):
+        """If at least one batch succeeds, return whatever we got — no sentinel."""
+        from tradingview_mcp.core.services import scanner_service
+
+        call_count = {"n": 0}
+
+        def first_fails_rest_ok(*, screener, interval, symbols):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise JSONDecodeError("Expecting value", "", 0)
+            return _make_batch_response(symbols)
+
+        with patch.object(scanner_service, "get_multiple_analysis", side_effect=first_fails_rest_ok), \
+             patch.object(scanner_service, "load_symbols", return_value=[f"SYM{i}" for i in range(250)]):
+            # Must NOT raise — partial success is success.
+            result = scanner_service.volume_breakout_scan(
+                exchange="KUCOIN",
+                timeframe="15m",
+                limit=200,
+            )
+
+        assert isinstance(result, list)
+        # Batches 2 and 3 succeeded (100 + 50 symbols).
+        assert len(result) > 0
+
+    def test_empty_symbol_list_returns_empty_no_raise(self):
+        """No symbols loaded => no batches attempted => no sentinel (early return)."""
+        from tradingview_mcp.core.services import scanner_service
+
+        with patch.object(scanner_service, "load_symbols", return_value=[]):
+            result = scanner_service.volume_breakout_scan(exchange="UNKNOWN")
+
+        assert result == []
+
+
+# --- Tests for fetch_trending_analysis --------------------------------------
+
+class TestFetchTrendingAnalysisSentinel:
+    def test_all_batches_fail_raises(self):
+        from tradingview_mcp.core.services import screener_service
+
+        def always_fail(*_args, **_kwargs):
+            raise JSONDecodeError("Expecting value", "", 0)
+
+        # batch_size=200, so 250 symbols => 2 batches attempted.
+        with patch.object(screener_service, "get_multiple_analysis", side_effect=always_fail), \
+             patch.object(screener_service, "load_symbols", return_value=[f"S{i}" for i in range(250)]):
+            with pytest.raises(BatchExecutionError) as exc_info:
+                screener_service.fetch_trending_analysis(exchange="KUCOIN", timeframe="15m")
+
+        assert exc_info.value.batches_attempted == 2
+        assert exc_info.value.batches_failed == 2
+
+    def test_partial_failure_no_raise(self):
+        from tradingview_mcp.core.services import screener_service
+
+        call_count = {"n": 0}
+
+        def second_fails(*, screener, interval, symbols):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise JSONDecodeError("Expecting value", "", 0)
+            # First batch returns rich enough data for compute_metrics to pass.
+            return {
+                f"KUCOIN:{s}": _FakeAnalysis(
+                    indicators={
+                        "open": 100.0,
+                        "close": 110.0,
+                        "high": 112.0,
+                        "low": 99.0,
+                        "BB.upper": 115.0,
+                        "BB.lower": 95.0,
+                        "SMA20": 105.0,
+                        "EMA50": 100.0,
+                        "RSI": 55.0,
+                        "volume": 1_000_000.0,
+                        "Recommend.All": 0.2,
+                    }
+                )
+                for s in symbols
+            }
+
+        with patch.object(screener_service, "get_multiple_analysis", side_effect=second_fails), \
+             patch.object(screener_service, "load_symbols", return_value=[f"S{i}" for i in range(250)]):
+            result = screener_service.fetch_trending_analysis(exchange="KUCOIN", timeframe="15m", limit=300)
+
+        assert isinstance(result, list)
+        # First batch (200 symbols) survived; second batch failure was swallowed
+        # because at least one batch succeeded.
+        assert len(result) > 0

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,104 @@
+"""Tests for the structured error envelope and exception types."""
+from __future__ import annotations
+
+import pytest
+
+from tradingview_mcp.core.errors import (
+    BatchExecutionError,
+    ErrorCode,
+    is_error,
+    make_error,
+)
+
+
+class TestErrorCode:
+    def test_codes_are_strings(self):
+        # Stable string values survive JSON serialization without extra encoding.
+        for code in ErrorCode:
+            assert isinstance(code.value, str)
+            assert code.value == code.value.upper()
+            assert " " not in code.value
+
+    def test_all_batches_failed_value_is_stable(self):
+        # Other code (skills, clients) string-compares against this literal.
+        assert ErrorCode.ALL_BATCHES_FAILED.value == "ALL_BATCHES_FAILED"
+
+
+class TestMakeError:
+    def test_basic_envelope_shape(self):
+        env = make_error(ErrorCode.NO_DATA, "nothing returned")
+        assert env == {"error": {"code": "NO_DATA", "message": "nothing returned"}}
+
+    def test_accepts_raw_string_code(self):
+        # Forward-compat: external callers don't have to import the enum.
+        env = make_error("CUSTOM_CODE", "details")
+        assert env["error"]["code"] == "CUSTOM_CODE"
+
+    def test_extra_kwargs_merge_into_error_dict(self):
+        env = make_error(
+            ErrorCode.ALL_BATCHES_FAILED,
+            "all 5 batches failed",
+            batches_attempted=5,
+            batches_failed=5,
+            first_error="JSONDecodeError",
+        )
+        err = env["error"]
+        assert err["code"] == "ALL_BATCHES_FAILED"
+        assert err["message"] == "all 5 batches failed"
+        assert err["batches_attempted"] == 5
+        assert err["batches_failed"] == 5
+        assert err["first_error"] == "JSONDecodeError"
+
+    def test_no_extra_kwargs_omits_extras(self):
+        env = make_error(ErrorCode.NO_DATA, "msg")
+        assert set(env["error"].keys()) == {"code", "message"}
+
+
+class TestIsError:
+    def test_new_envelope_detected(self):
+        assert is_error(make_error(ErrorCode.NO_DATA, "x")) is True
+
+    def test_envelope_with_extras_detected(self):
+        env = make_error(ErrorCode.UPSTREAM_RATE_LIMIT, "rate limited", retry_after_s=30)
+        assert is_error(env) is True
+
+    def test_legacy_string_error_is_not_an_envelope(self):
+        # The point of the new shape is to be distinguishable from the prior
+        # ad-hoc ``{"error": "Analysis failed: ..."}`` strings.
+        assert is_error({"error": "Analysis failed: something"}) is False
+
+    def test_non_dict_payload_not_envelope(self):
+        assert is_error("error") is False
+        assert is_error(None) is False
+        assert is_error([{"error": {"code": "X", "message": "y"}}]) is False
+        assert is_error(42) is False
+
+    def test_dict_without_error_key_not_envelope(self):
+        assert is_error({"result": [], "ok": True}) is False
+
+    def test_dict_with_error_but_missing_code_not_envelope(self):
+        # Catches partially-constructed envelopes; clients should still treat
+        # the response as malformed rather than as a known error type.
+        assert is_error({"error": {"message": "msg"}}) is False
+
+
+class TestBatchExecutionError:
+    def test_stores_batch_metadata(self):
+        exc = BatchExecutionError(
+            batches_attempted=4,
+            batches_failed=4,
+            first_error="JSONDecodeError('Expecting value', '', 0)",
+        )
+        assert exc.batches_attempted == 4
+        assert exc.batches_failed == 4
+        assert exc.first_error == "JSONDecodeError('Expecting value', '', 0)"
+
+    def test_string_message_includes_first_error(self):
+        exc = BatchExecutionError(batches_attempted=3, batches_failed=3, first_error="boom")
+        msg = str(exc)
+        assert "3" in msg
+        assert "boom" in msg
+
+    def test_is_a_real_exception(self):
+        with pytest.raises(BatchExecutionError):
+            raise BatchExecutionError(1, 1, "x")


### PR DESCRIPTION
## Summary

Adds a typed error format and surfaces total upstream failures in batched scanners so callers can distinguish **"no matches today"** from **"upstream rate-limit cliff"** — a problem that's been silently degrading scanner reliability since the batch loops were written.

Lays the groundwork for richer error handling across the codebase (#32's retry layer recovered from hits; this surfaces hits that retry exhausted).

## Why this matters

`scanner_service.volume_breakout_scan` and `screener_service.fetch_trending_analysis` both do:

```python
for batch in batches:
    try:
        analysis = get_multiple_analysis(...)
    except Exception:
        continue   # ← silently swallows
```

When TradingView rate-limits **every** batch (a real failure mode, especially around bursty parallel use — see #34's throttle), callers get the same `[]` they'd get on a quiet day. They can't tell the upstream is down. Skills/agents that wrap these tools treat the empty list as "no signal" and trade on stale assumptions.

## What changes

### 1. New module — `core/errors.py` (120 lines + 15 tests)

- **`ErrorCode`** enum with stable string values (`ALL_BATCHES_FAILED`, `UPSTREAM_RATE_LIMIT`, `NO_DATA`, `SYMBOL_NOT_FOUND`, `DEPENDENCY_MISSING`, ...). String values so they survive JSON serialization and can be string-compared from any language.
- **`make_error(code, message, **extras)`** constructs `{"error": {"code", "message", **extras}}`.
- **`is_error(payload)`** helper that explicitly rejects the legacy string-error shape — so callers can switch safely without false-positives against old responses.
- **`BatchExecutionError`** exception carrying `batches_attempted`, `batches_failed`, `first_error`.

### 2. Batch sentinel — 2 services

`scanner_service.volume_breakout_scan` and `screener_service.fetch_trending_analysis` now:
- Track `batches_attempted` / `batches_failed` / `first_error` per call
- Log each batch failure to stderr (mirrors the existing `screener_provider` stderr pattern from #32)
- Raise `BatchExecutionError` **only when every batch failed**
- Partial success still returns the partial list — **no behavior change** for callers that occasionally see flaky batches

### 3. MCP tool wrappers — `server.py`

5 tools convert the exception into an error envelope at the MCP boundary:

| Tool | Underlying service |
|------|---------------------|
| `top_gainers` | `fetch_trending_analysis` |
| `top_losers` | `fetch_trending_analysis` |
| `rating_filter` | `fetch_trending_analysis` |
| `volume_breakout_scanner` | `volume_breakout_scan` |
| `smart_volume_scanner` | `volume_breakout_scan` (inherited via inner call) |

Their declared return type becomes `list[dict] | dict`.

### 4. Tests — **21 new, all passing**

- `tests/unit/test_errors.py` (15 tests): `ErrorCode` value stability, `make_error` envelope shape + extras, `is_error` rejection of legacy/`None`/partial shapes, `BatchExecutionError` attributes & raising.
- `tests/unit/services/test_batch_sentinel.py` (6 tests): all-fail / all-succeed / partial-fail / empty-symbols paths for both adopted scanners, using mocked `get_multiple_analysis` + `load_symbols`.

**Full suite: 106 passed (85 prior + 21 new), 0.17s.**

### 5. `.gitignore` companion fix

Extends the `!src/**/test_*.py` exception with `!tests/**/test_*.py` so the new tests (and any future ones under `tests/`) aren't silently ignored by the global `test_*.py` rule. Prior test files predated that rule so weren't blocked, but new ones were.

### 6. README

New ⚠️ **Error Envelope Format** section listing the 5 adopted tools, the envelope shape, and a 7-line caller snippet showing the `isinstance(result, dict) and \"error\" in result` migration pattern.

## Migration / breaking note

Adopted tools that previously always returned `list[dict]` may now return a `dict` envelope on total upstream failure. Callers that did `for row in result:` without checking the type will raise `TypeError`. Migration is one isinstance check (documented in the new README section).

**Not adopted in this PR** (left for follow-ups in the same pattern): `coin_analysis` (single-symbol — no batch loop), `bollinger_scan` (single-batch), `multi_agent_analysis`, the EGX family, the candle pattern scanners. Adopting them is mostly mechanical given the helpers this PR adds.

## Manual smoke

Server still loads cleanly (`server.py: 31 tools registered`); no regressions in any existing test.

## Diff stats

```
.gitignore                                          |   1 +
README.md                                           |  30 ++++
src/tradingview_mcp/core/errors.py                  | 120 +++++++++++++
src/tradingview_mcp/core/services/scanner_service.py |  37 +++-
src/tradingview_mcp/core/services/screener_service.py|  35 +++-
src/tradingview_mcp/server.py                       |  87 +++++++--
tests/unit/services/__init__.py                     |   0
tests/unit/services/test_batch_sentinel.py          | 185 +++++++++++++++++++
tests/unit/test_errors.py                           | 104 +++++++++++
9 files changed, 585 insertions(+), 14 deletions(-)
```