### PR TITLE
docs: add TweetClaw companion for OpenClaw market context

### DIFF
--- a/OPENCLAW.md
+++ b/OPENCLAW.md
@@ -173,6 +173,20 @@ Your OpenClaw agent will have access to all tradingview tools via the wrapper:
 - `analyze_sentiment` — Reddit sentiment for any ticker
 - `fetch_news_summary` — Latest news from financial RSS feeds
 
+### Optional Companion: X/Twitter Market Context
+
+Install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) when the same OpenClaw agent needs public X/Twitter signals alongside `tradingview-mcp` data:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Keep responsibilities split:
+- `tradingview-mcp`: prices, screeners, indicators, backtests, Reddit sentiment, and RSS news
+- TweetClaw: scrape tweets, search tweets, search tweet replies, follower export, user lookup, media upload/download, direct messages, monitors, webhooks, giveaway draws, and approval-reviewed post tweets or replies through Xquik
+
+The canonical package is [`@xquik/tweetclaw`](https://www.npmjs.com/package/@xquik/tweetclaw). Live calls require a Xquik API key from [dashboard.xquik.com](https://dashboard.xquik.com/), but the plugin can install before credentials are configured.
+
 ### Screener
 - `screener_bullish`, `screener_oversold`, `screener_strong_trend` — TradingView screener
 - `egx_stock_screen` — Egyptian Exchange specific screening

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Backtesting + Live Sentiment + Yahoo Finance + 30+ Technical Analysis Tools — 
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![MCP Ready](https://img.shields.io/badge/MCP-Ready-brightgreen)](https://modelcontextprotocol.com/)
+[![MCP Ready](https://img.shields.io/badge/MCP-Ready-brightgreen)](https://modelcontextprotocol.io/)
 [![OpenClaw Ready](https://img.shields.io/badge/OpenClaw-Ready-blueviolet)](https://openclaw.ai)
 [![Version](https://img.shields.io/badge/version-v0.7.0-blue)](https://github.com/atilaahmettaner/tradingview-mcp/releases)
 [![PyPI](https://img.shields.io/badge/PyPI-tradingview--mcp--server-orange)](https://pypi.org/project/tradingview-mcp-server/)
@@ -241,6 +241,16 @@ market snapshot
 backtest RSI strategy for AAPL, 1 year
 compare all strategies for BTC-USD
 ```
+
+### Optional: X/Twitter Market Context
+
+If your OpenClaw trading bot also needs public X/Twitter chatter around tickers, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) as a companion plugin:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Use `tradingview-mcp` for prices, indicators, backtests, Reddit sentiment, and RSS news. Use TweetClaw when a prompt asks to scrape tweets, search tweets, search tweet replies, export followers, look up users, monitor tweets, deliver webhooks, run giveaway draws, or post tweets and replies after explicit user approval. The canonical package is [`@xquik/tweetclaw`](https://www.npmjs.com/package/@xquik/tweetclaw); live calls require a Xquik API key from [dashboard.xquik.com](https://dashboard.xquik.com/).
 
 👉 **[Full OpenClaw Setup Guide →](OPENCLAW.md)**
 


### PR DESCRIPTION
## Summary
- Add an optional TweetClaw companion section to the OpenClaw README path for X/Twitter market chatter around tickers.
- Keep tradingview-mcp responsible for prices, indicators, backtests, Reddit sentiment, and RSS news.
- Update the MCP badge target to modelcontextprotocol.io because the old domain no longer resolves.

## Validation
- Diff whitespace check passed.
- Changed-line dash scan passed.
- Changed-line token-like string scan passed.
- README and OPENCLAW link sweep: 26 external OK, 1 existing S3 demo asset expected 403, 3 local OK.
- npm metadata returned @xquik/tweetclaw 1.6.31.

Tests not run because this is documentation only.