### PR TITLE
feat(validators): add TADAWUL (Saudi Arabia/TASI) market support

### DIFF
--- a/src/tradingview_mcp/core/utils/validators.py
+++ b/src/tradingview_mcp/core/utils/validators.py
@@ -22,6 +22,7 @@ STOCK_EXCHANGES: Set[str] = {
     "asx",
     "sse", "szse", "chn",
     "twse", "tpex",
+    "tadawul", "tasi",                  # Saudi Stock Exchange (Tadawul) — All Share Index (TASI)
 }
 
 EXCHANGE_SCREENER = {
@@ -63,6 +64,9 @@ EXCHANGE_SCREENER = {
     # Taiwan Stock Market Support
     "twse": "taiwan",       # Taiwan Stock Exchange (臺灣證券交易所)
     "tpex": "taiwan",       # Taipei Exchange (櫃買中心, OTC market)
+    # Saudi Stock Market (Tadawul) — TradingView scanner uses /ksa/
+    "tadawul": "ksa",
+    "tasi": "ksa",          # alias: Tadawul All Share Index
 }
 
 # Map validated exchange identifiers to their canonical TradingView symbol prefix.
@@ -90,6 +94,8 @@ _EXCHANGE_TV_PREFIX: dict = {
     "chn": "SSE",
     "twse": "TWSE",
     "tpex": "TPEX",
+    "tadawul": "TADAWUL",
+    "tasi": "TADAWUL",
 }
 
 _YAHOO_SYMBOL_ALIASES: dict = {


### PR DESCRIPTION
## Summary

Adds the Saudi Stock Exchange (Tadawul, TASI) as a supported stock market alongside the existing EGX / BIST / NASDAQ / NYSE / BURSA / HKEX / SSE / SZSE / TWSE / TPEX set. Purely additive — no existing behaviour changes.

## What changed

`src/tradingview_mcp/core/utils/validators.py`:

- `STOCK_EXCHANGES`: register `tadawul` and `tasi` aliases.
- `EXCHANGE_SCREENER`: map both to TradingViews `ksa` market identifier (verified live against `https://scanner.tradingview.com/ksa/scan`).
- `_EXCHANGE_TV_PREFIX`: map both to the `TADAWUL` symbol prefix used by TradingView for Saudi tickers (e.g. `TADAWUL:2222` for Aramco).

## Why this is useful

The Saudi market is one of the largest in MENA by market cap and has solid TradingView data coverage. Existing users of the EGX/BIST tools (which target the same region) had no path to Saudi tickers — this PR closes that gap without touching any of the tool surface area.

After this change, the existing generic screener tools (`top_gainers`, `top_losers`, `bollinger_scan`, `rating_filter`, `coin_analysis`, `multi_agent_analysis`, `multi_timeframe_analysis`, `combined_analysis`) work with `exchange=TADAWUL` or `exchange=TASI` out of the box. No additional tool registrations or service-layer changes were needed.

## How I tested

Live calls via `screener_provider.fetch_screener_indicators` against:

- `TADAWUL:2222` (Saudi Aramco) → close 27.9 SAR, RSI 58.2
- `TADAWUL:1180` (Saudi National Bank) → close 39.4, RSI 47.8
- `TADAWUL:7010` (STC) → close 44.04, RSI 64.9

Exchange-scan mode (`Column(exchange) == TADAWUL`) also returned the expected top-volume Saudi names (Al Rajhi, Aramco, etc.).

## Test plan

- [ ] `top_gainers(exchange=TADAWUL, timeframe=1D)` returns rows
- [ ] `coin_analysis(symbol=2222, exchange=TADAWUL)` returns indicators
- [ ] Existing `egx_*`, `nasdaq`, `kucoin`, `binance` flows still work unchanged

## Notes for reviewer

- TASI symbols are numeric (e.g. `2222`, `1180`, `7010`), which `normalize_tradingview_symbol(symbol, TADAWUL)` already handles correctly via the existing `f{prefix}:{symbol}` fallback — no special-casing required.
- I did not add a `tadawul.txt` to `coinlist/` since `advanced_candle_pattern` is the only tool that needs it. The screener tools all use exchange-scan mode and dont need a pre-built list. Happy to add one in a follow-up if you'd like.
- No tool docstring updates included — the existing wording (etc.) still applies. Let me know if you'd prefer explicit TADAWUL mentions added to the docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)