### PR TITLE
Add Shariah compliance screening

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://trendshift.io/repositories/25110" target="_blank"><img src="https://trendshift.io/api/badge/repositories/25110" alt="atilaahmettaner%2Ftradingview-mcp | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 **The most complete AI-powered trading toolkit for Claude and MCP clients.**
-Backtesting + Live Sentiment + Yahoo Finance + 30+ Technical Analysis Tools — all in one MCP server.
+Backtesting + Live Sentiment + Yahoo Finance + Shariah Compliance + 30+ Technical Analysis Tools — all in one MCP server.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -53,6 +53,7 @@ https://github-production-user-asset-6210df.s3.amazonaws.com/67838093/478689497-
 | **Backtesting** | ✅ 6 strategies + Sharpe | ❌ Manual scripting | ✅ Proprietary |
 | **Live Sentiment** | ✅ Reddit + RSS news | ❌ Separate setup | ✅ Terminal |
 | **Market Data** | ✅ Live / Real-Time | Historical / Delayed | Live |
+| **Shariah Screening** | ✅ AAOIFI Standard No. 21 | ❌ Not available | ❌ Not available |
 | **API Keys** | **None required** | Multiple (OpenAI, etc.) | N/A |
 
 ---
@@ -255,12 +256,31 @@ Unlike basic screeners, this framework deploys **specialized AI agents** that de
 1. **🛠️ Technical Analyst** — Bollinger Bands (±3 proprietary rating), RSI, MACD
 2. **🌊 Sentiment & Momentum Analyst** — Reddit community sentiment + price momentum
 3. **🛡️ Risk Manager** — Volatility, drawdown risk, mean-reversion signals
+4. **🕌 Shariah Advisor** — AAOIFI Standard No. 21 compliance + purification rate
 
 *Output: `STRONG BUY` / `BUY` / `HOLD` / `SELL` / `STRONG SELL` with confidence score*
 
 ---
 
 ## 🔧 All 30+ MCP Tools
+
+### 🕌 Shariah Compliance
+
+| Tool | Description |
+|------|-------------|
+| `check_shariah_compliance` | Full AAOIFI screen for one stock: business activity, debt/cash/receivables ratios, and purification rate |
+| `check_shariah_compliance_bulk` | Screen up to 20 comma-separated tickers with summary counts and individual reports |
+
+The screen uses Yahoo Finance public JSON endpoints and applies AAOIFI Standard No. 21-style checks:
+
+- Qualitative screen for prohibited business activities such as conventional banking, insurance, alcohol, tobacco, gambling, adult entertainment, and weapons.
+- Quantitative screen requiring total debt, cash plus securities, and accounts receivable to each stay below 30% of market capitalization.
+- Purification rate calculated as interest income divided by total revenue when that data is available.
+
+```
+Example prompt: "Is Apple halal to invest in?"
+→ HALAL with purification | Debt 16.7% | Cash 6.7% | Receivables 3.3%
+```
 
 ### 📊 Backtesting Engine *(New in v0.6.0)*
 
@@ -353,6 +373,13 @@ AI: [compare_strategies] → Supertrend #1 (+14.6%, Sharpe 3.09), MACD last (-9.
 
 You: "Analyze TSLA with all signals: technical + sentiment + news"
 AI: [combined_analysis] → BUY (Technical STRONG BUY + Bullish Reddit + Positive news)
+
+You: “Is Apple halal to invest in?”
+AI: [check_shariah_compliance] → HALAL (with purification 0.42%)
+Debt 18.3% | Cash 4.1% | Receivables 2.9%
+
+You: "Are AAPL, MSFT, and JPM Shariah compliant?"
+AI: [check_shariah_compliance_bulk] → 2 halal, 1 haram, with AAOIFI ratio details
 ```
 
 ---

--- a/src/tradingview_mcp/core/services/shariah_service.py
+++ b/src/tradingview_mcp/core/services/shariah_service.py
@@ -1,0 +1,584 @@
+"""
+AAOIFI Shariah compliance screening service.
+
+The service performs a two-stage screen:
+1. Business activity exclusion for prohibited sectors and industries.
+2. Financial ratio checks against AAOIFI Standard No. 21 thresholds.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import Any
+
+from tradingview_mcp.core.services.options_service import _fetch as _fetch_yahoo_json
+
+logger = logging.getLogger(__name__)
+
+_QUOTE_SUMMARY_BASE = "https://query2.finance.yahoo.com/v10/finance/quoteSummary"
+_TIMESERIES_BASE = "https://query2.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries"
+_TIMESERIES_TYPES = (
+    "annualTotalDebt",
+    "annualCashCashEquivalentsAndShortTermInvestments",
+    "annualAccountsReceivable",
+    "annualNetReceivables",
+    "annualTotalRevenue",
+    "annualInterestIncome",
+    "annualInterestIncomeNonOperating",
+)
+_PERIOD_START = 493590046
+
+DEBT_THRESHOLD = 0.30
+CASH_THRESHOLD = 0.30
+RECEIVABLES_THRESHOLD = 0.30
+MAX_BULK_SYMBOLS = 20
+
+PROHIBITED_KEYWORDS: tuple[str, ...] = (
+    "bank",
+    "banking",
+    "insurance",
+    "conventional finance",
+    "credit",
+    "mortgage",
+    "lending",
+    "alcohol",
+    "alcoholic",
+    "brewery",
+    "brewing",
+    "winery",
+    "distillery",
+    "spirits",
+    "tobacco",
+    "cigarette",
+    "cigar",
+    "pork",
+    "swine",
+    "pig farming",
+    "gambling",
+    "casino",
+    "lottery",
+    "betting",
+    "gaming",
+    "adult entertainment",
+    "pornography",
+    "xxx",
+    "weapons",
+    "defence",
+    "defense contractor",
+    "arms",
+    "cannabis",
+)
+
+PROHIBITED_DESCRIPTION_KEYWORDS: tuple[str, ...] = (
+    "conventional banking",
+    "conventional finance",
+    "insurance company",
+    "mortgage lender",
+    "payday lending",
+    "alcoholic beverages",
+    "brewery",
+    "breweries",
+    "winery",
+    "distillery",
+    "tobacco products",
+    "cigarette",
+    "cigar",
+    "pork products",
+    "pig farming",
+    "casino",
+    "gambling",
+    "lottery",
+    "sports betting",
+    "adult entertainment",
+    "pornography",
+    "defense contractor",
+    "weapons manufacturer",
+    "arms dealer",
+    "cannabis",
+)
+
+PROHIBITED_INDUSTRIES: tuple[str, ...] = (
+    "banks-regional",
+    "banks-diversified",
+    "insurance-life",
+    "insurance-property & casualty",
+    "insurance-diversified",
+    "insurance-reinsurance",
+    "insurance-specialty",
+    "asset management",
+    "capital markets",
+    "financial data & stock exchanges",
+    "mortgage finance",
+    "credit services",
+    "beverages-wineries & distilleries",
+    "beverages-brewers",
+    "tobacco",
+    "gambling",
+    "adult entertainment",
+    "defense contractors",
+    "aerospace & defense",
+)
+
+
+@dataclass
+class ShariahResult:
+    """Structured result for one AAOIFI Shariah screening report."""
+
+    symbol: str
+    name: str
+    sector: str
+    industry: str
+    sector_screen_passed: bool = True
+    sector_screen_reason: str = ""
+    market_cap: float = 0.0
+    total_debt: float = 0.0
+    cash_and_securities: float = 0.0
+    accounts_receivable: float = 0.0
+    total_revenue: float = 0.0
+    interest_income: float = 0.0
+    interest_income_available: bool = False
+    debt_ratio: float = 0.0
+    cash_ratio: float = 0.0
+    receivables_ratio: float = 0.0
+    purification_rate: float = 0.0
+    quantitative_passed: bool = True
+    failed_ratios: list[str] = field(default_factory=list)
+    compliant: bool = False
+    verdict: str = ""
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Return an MCP-friendly dictionary report."""
+
+        def pct(value: float) -> str:
+            return f"{value * 100:.2f}%"
+
+        def ratio_status(value: float, threshold: float) -> dict:
+            return {
+                "value": pct(value),
+                "passed": value < threshold,
+                "limit": pct(threshold),
+            }
+
+        return {
+            "symbol": self.symbol,
+            "name": self.name,
+            "sector": self.sector,
+            "industry": self.industry,
+            "methodology": "AAOIFI Standard No. 21",
+            "status": "halal" if self.compliant else "haram",
+            "verdict": self.verdict,
+            "compliant": self.compliant,
+            "screening": {
+                "qualitative_screen": {
+                    "status": "PASSED" if self.sector_screen_passed else "FAILED",
+                    "detail": self.sector_screen_reason
+                    or "No prohibited business activity detected",
+                },
+                "quantitative_screen": {
+                    "status": "PASSED" if self.quantitative_passed else "FAILED",
+                    "ratios": {
+                        "debt_to_market_cap": ratio_status(
+                            self.debt_ratio,
+                            DEBT_THRESHOLD,
+                        ),
+                        "cash_securities_to_market_cap": ratio_status(
+                            self.cash_ratio,
+                            CASH_THRESHOLD,
+                        ),
+                        "receivables_to_market_cap": ratio_status(
+                            self.receivables_ratio,
+                            RECEIVABLES_THRESHOLD,
+                        ),
+                    },
+                    "failed_ratios": self.failed_ratios,
+                },
+            },
+            "purification": {
+                "rate": pct(self.purification_rate),
+                "available": self.interest_income_available,
+                "note": (
+                    "Donate this percentage of income or dividends received to charity."
+                    if self.purification_rate > 0
+                    else "No purification required based on available interest income data."
+                    if self.interest_income_available
+                    else "Unable to calculate purification because interest income data is unavailable."
+                ),
+            },
+            "raw_financials": {
+                "market_cap": self.market_cap,
+                "total_debt": self.total_debt,
+                "cash_and_securities": self.cash_and_securities,
+                "accounts_receivable": self.accounts_receivable,
+                "total_revenue": self.total_revenue,
+                "interest_income": self.interest_income,
+            },
+            "warnings": self.warnings,
+            "disclaimer": (
+                "For informational purposes only. Not a fatwa. "
+                "Consult a qualified Shariah scholar before investing."
+            ),
+        }
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Convert financial statement values to finite floats."""
+    try:
+        if value is None:
+            return default
+        parsed = float(value)
+        return parsed if parsed == parsed else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_text(value: str) -> str:
+    """Normalize punctuation that varies between Yahoo Finance data sources."""
+    return (
+        value.lower()
+        .replace("—", "-")
+        .replace("–", "-")
+        .replace(" - ", "-")
+        .strip()
+    )
+
+
+def _raw_value(value: Any, default: float = 0.0) -> float:
+    """Extract Yahoo's common {raw, fmt} value shape as a float."""
+    if isinstance(value, dict):
+        value = value.get("raw")
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _fetch_quote_summary(symbol: str) -> dict:
+    """Fetch Yahoo quote summary profile, price, and high-level financial data."""
+    modules = "assetProfile,price,financialData"
+    encoded_symbol = urllib.parse.quote(symbol)
+    url = f"{_QUOTE_SUMMARY_BASE}/{encoded_symbol}?modules={modules}"
+    data = _fetch_yahoo_json(url)
+    results = data.get("quoteSummary", {}).get("result") or []
+    if not results:
+        error = data.get("quoteSummary", {}).get("error") or "empty Yahoo quote summary"
+        raise ValueError(str(error))
+    return results[0]
+
+
+def _fetch_timeseries(symbol: str) -> dict:
+    """Fetch annual Yahoo fundamentals timeseries used by the ratio screen."""
+    encoded_symbol = urllib.parse.quote(symbol)
+    query = urllib.parse.urlencode(
+        {
+            "symbol": symbol,
+            "type": ",".join(_TIMESERIES_TYPES),
+            "period1": _PERIOD_START,
+            "period2": int(time.time()),
+        }
+    )
+    url = f"{_TIMESERIES_BASE}/{encoded_symbol}?{query}"
+    data = _fetch_yahoo_json(url)
+    return data.get("timeseries", {})
+
+
+def _latest_timeseries_value(timeseries: dict, *type_names: str) -> tuple[float, bool, str]:
+    """Return the latest usable raw value for the first matching Yahoo type."""
+    results = timeseries.get("result") or []
+    wanted = set(type_names)
+
+    for item in results:
+        types = item.get("meta", {}).get("type") or []
+        matched_types = [type_name for type_name in types if type_name in wanted]
+        for type_name in matched_types:
+            values = item.get(type_name) or []
+            for entry in reversed(values):
+                raw = _raw_value(entry.get("reportedValue"))
+                if raw == raw:
+                    return raw, True, entry.get("asOfDate") or ""
+    return 0.0, False, ""
+
+
+def _matching_period_value(
+    timeseries: dict,
+    expected_date: str,
+    *type_names: str,
+) -> tuple[float, bool, str]:
+    """Return a value only when Yahoo reports it for the expected annual period."""
+    results = timeseries.get("result") or []
+    wanted = set(type_names)
+
+    for item in results:
+        types = item.get("meta", {}).get("type") or []
+        matched_types = [type_name for type_name in types if type_name in wanted]
+        for type_name in matched_types:
+            values = item.get(type_name) or []
+            for entry in reversed(values):
+                if entry.get("asOfDate") != expected_date:
+                    continue
+                raw = _raw_value(entry.get("reportedValue"))
+                if raw == raw:
+                    return raw, True, entry.get("asOfDate") or ""
+    return 0.0, False, ""
+
+
+def _keyword_matches(text: str, keyword: str) -> bool:
+    """Return whether a prohibited keyword matches without known false positives."""
+    if keyword in {"alcohol", "alcoholic"} and (
+        "non-alcohol" in text or "non alcoholic" in text or "nonalcohol" in text
+    ):
+        return False
+    if keyword == "alcoholic beverages" and (
+        "non-alcoholic beverages" in text
+        or "non alcoholic beverages" in text
+        or "nonalcoholic beverages" in text
+    ):
+        return False
+    return keyword in text
+
+
+def _qualitative_screen(sector: str, industry: str, description: str) -> tuple[bool, str]:
+    """Run the prohibited activity screen for business sector and industry."""
+    sector_lower = _normalize_text(sector)
+    industry_lower = _normalize_text(industry)
+    description_lower = _normalize_text(description)
+
+    for prohibited in PROHIBITED_INDUSTRIES:
+        if prohibited in industry_lower:
+            return False, f"Prohibited industry: {industry}"
+
+    sector_industry_text = f"{sector_lower} {industry_lower}"
+    for keyword in PROHIBITED_KEYWORDS:
+        if not _keyword_matches(sector_industry_text, keyword):
+            continue
+        if keyword == "gaming" and "electronic gaming" in sector_industry_text:
+            continue
+        return False, f"Prohibited activity keyword detected: {keyword}"
+
+    for keyword in PROHIBITED_DESCRIPTION_KEYWORDS:
+        if _keyword_matches(description_lower, keyword):
+            return False, f"Prohibited activity described: {keyword}"
+
+    return True, ""
+
+
+def _quantitative_screen(
+    market_cap: float,
+    total_debt: float,
+    cash_and_securities: float,
+    accounts_receivable: float,
+) -> tuple[bool, float, float, float, list[str]]:
+    """Run AAOIFI financial ratio checks against market capitalization."""
+    if market_cap <= 0:
+        return False, 0.0, 0.0, 0.0, ["Market cap unavailable; cannot compute ratios"]
+
+    debt_ratio = total_debt / market_cap
+    cash_ratio = cash_and_securities / market_cap
+    receivables_ratio = accounts_receivable / market_cap
+    failed: list[str] = []
+
+    if debt_ratio >= DEBT_THRESHOLD:
+        failed.append(f"Debt ratio {debt_ratio * 100:.1f}% >= 30% threshold")
+    if cash_ratio >= CASH_THRESHOLD:
+        failed.append(f"Cash/securities ratio {cash_ratio * 100:.1f}% >= 30% threshold")
+    if receivables_ratio >= RECEIVABLES_THRESHOLD:
+        failed.append(f"Receivables ratio {receivables_ratio * 100:.1f}% >= 30% threshold")
+
+    return not failed, debt_ratio, cash_ratio, receivables_ratio, failed
+
+
+def _purification_rate(interest_income: float, total_revenue: float) -> float:
+    """Calculate purification rate as non-compliant income over total revenue."""
+    if total_revenue <= 0 or interest_income <= 0:
+        return 0.0
+    return min(interest_income / total_revenue, 1.0)
+
+
+def screen_shariah(symbol: str) -> dict:
+    """Screen one stock ticker for AAOIFI Shariah compliance."""
+    normalized_symbol = symbol.strip().upper()
+    if not normalized_symbol:
+        return {"error": "No symbol provided."}
+
+    result = ShariahResult(symbol=normalized_symbol, name="", sector="", industry="")
+
+    try:
+        quote_summary = _fetch_quote_summary(normalized_symbol)
+        profile = quote_summary.get("assetProfile") or {}
+        price = quote_summary.get("price") or {}
+        financial_data = quote_summary.get("financialData") or {}
+        timeseries = _fetch_timeseries(normalized_symbol)
+
+        result.name = price.get("longName") or price.get("shortName") or normalized_symbol
+        result.sector = profile.get("sector") or ""
+        result.industry = profile.get("industry") or ""
+        quote_type = (price.get("quoteType") or "").upper()
+        if quote_type and quote_type != "EQUITY":
+            return {
+                "symbol": normalized_symbol,
+                "name": result.name,
+                "quote_type": quote_type,
+                "error": "Shariah screening currently supports individual equities only.",
+                "verdict": "UNABLE TO SCREEN",
+                "disclaimer": "Not a fatwa. Consult a qualified Shariah scholar before investing.",
+            }
+        result.market_cap = _raw_value(price.get("marketCap"))
+
+        passed, reason = _qualitative_screen(
+            result.sector,
+            result.industry,
+            profile.get("longBusinessSummary") or "",
+        )
+        result.sector_screen_passed = passed
+        result.sector_screen_reason = reason
+
+        result.total_debt, debt_available, _ = _latest_timeseries_value(
+            timeseries,
+            "annualTotalDebt",
+        )
+        if not debt_available:
+            result.total_debt = _raw_value(financial_data.get("totalDebt"))
+            if result.total_debt <= 0:
+                result.warnings.append("Total debt unavailable; ratio may be incomplete.")
+
+        result.cash_and_securities, cash_available, _ = _latest_timeseries_value(
+            timeseries,
+            "annualCashCashEquivalentsAndShortTermInvestments",
+        )
+        if not cash_available:
+            result.cash_and_securities = _raw_value(financial_data.get("totalCash"))
+            if result.cash_and_securities <= 0:
+                result.warnings.append("Cash and securities unavailable; ratio may be incomplete.")
+
+        result.accounts_receivable, receivables_available, _ = _latest_timeseries_value(
+            timeseries,
+            "annualAccountsReceivable",
+            "annualNetReceivables",
+        )
+        if not receivables_available:
+            result.warnings.append("Accounts receivable unavailable; ratio may be incomplete.")
+
+        result.total_revenue, revenue_available, revenue_date = _latest_timeseries_value(
+            timeseries,
+            "annualTotalRevenue",
+        )
+        if not revenue_available:
+            result.total_revenue = _raw_value(financial_data.get("totalRevenue"))
+            result.warnings.append(
+                "Annual revenue unavailable; using Yahoo financialData totalRevenue if present."
+            )
+
+        (
+            result.interest_income,
+            result.interest_income_available,
+            interest_date,
+        ) = _matching_period_value(
+            timeseries,
+            revenue_date,
+            "annualInterestIncome",
+            "annualInterestIncomeNonOperating",
+        )
+        if not result.interest_income_available:
+            result.warnings.append(
+                "Interest income unavailable; purification rate cannot be calculated."
+            )
+        elif revenue_date and interest_date and interest_date != revenue_date:
+            result.interest_income = 0.0
+            result.interest_income_available = False
+            result.warnings.append(
+                "Interest income period does not match annual revenue period; purification rate cannot be calculated."
+            )
+
+        (
+            result.quantitative_passed,
+            result.debt_ratio,
+            result.cash_ratio,
+            result.receivables_ratio,
+            result.failed_ratios,
+        ) = _quantitative_screen(
+            result.market_cap,
+            result.total_debt,
+            result.cash_and_securities,
+            result.accounts_receivable,
+        )
+        if result.market_cap <= 0:
+            result.warnings.append(
+                "Market cap not found. Try a Yahoo Finance ticker format such as THYAO.IS."
+            )
+
+        result.purification_rate = _purification_rate(
+            result.interest_income,
+            result.total_revenue,
+        )
+        result.compliant = result.sector_screen_passed and result.quantitative_passed
+
+        if not result.sector_screen_passed:
+            result.verdict = "HARAM - prohibited business activity"
+        elif not result.quantitative_passed:
+            result.verdict = "HARAM - financial ratios exceed AAOIFI thresholds"
+        elif result.purification_rate > 0:
+            result.verdict = (
+                "HALAL with purification - donate "
+                f"{result.purification_rate * 100:.2f}% of income to charity"
+            )
+        elif not result.interest_income_available:
+            result.verdict = "HALAL - purification data unavailable"
+        else:
+            result.verdict = "HALAL - no purification required"
+    except Exception as exc:
+        logger.exception("Shariah screening failed for %s", normalized_symbol)
+        return {
+            "symbol": normalized_symbol,
+            "error": f"Screening failed: {exc}",
+            "verdict": "UNABLE TO SCREEN",
+            "disclaimer": "Not a fatwa. Consult a qualified Shariah scholar before investing.",
+        }
+
+    return result.to_dict()
+
+
+def screen_shariah_bulk(symbols: list[str]) -> dict:
+    """Screen multiple stock tickers for AAOIFI Shariah compliance."""
+    cleaned_symbols = [symbol.strip().upper() for symbol in symbols if symbol.strip()]
+    if not cleaned_symbols:
+        return {"error": "No symbols provided."}
+    if len(cleaned_symbols) > MAX_BULK_SYMBOLS:
+        return {"error": f"Maximum {MAX_BULK_SYMBOLS} symbols per bulk request."}
+
+    results: dict[str, dict] = {}
+    halal: list[str] = []
+    haram: list[str] = []
+    errors: list[str] = []
+
+    for symbol in cleaned_symbols:
+        report = screen_shariah(symbol)
+        results[symbol] = report
+        if "error" in report:
+            errors.append(symbol)
+        elif report.get("compliant"):
+            halal.append(symbol)
+        else:
+            haram.append(symbol)
+
+    return {
+        "summary": {
+            "total_screened": len(cleaned_symbols),
+            "halal": len(halal),
+            "haram": len(haram),
+            "errors": len(errors),
+            "halal_list": halal,
+            "haram_list": haram,
+            "compliant": len(halal),
+            "non_compliant": len(haram),
+            "compliant_list": halal,
+            "non_compliant_list": haram,
+            "error_list": errors,
+        },
+        "methodology": "AAOIFI Standard No. 21",
+        "results": results,
+        "disclaimer": "For informational purposes only. Not a fatwa.",
+    }

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -48,6 +48,10 @@ from tradingview_mcp.core.services.yahoo_finance_service import (
     get_price,
     get_market_snapshot,
 )
+from tradingview_mcp.core.services.shariah_service import (
+    screen_shariah,
+    screen_shariah_bulk,
+)
 from tradingview_mcp.core.services.bitcoin_market_service import get_bitcoin_market_pulse
 from tradingview_mcp.core.services.extended_hours_service import get_extended_hours_price
 from tradingview_mcp.core.services.options_service import (
@@ -82,7 +86,7 @@ mcp = FastMCP(
         "Supports crypto exchanges (KuCoin, Binance, Bybit, MEXC, etc.) and stock markets "
         "(EGX, BIST, NASDAQ, NYSE, Bursa Malaysia, HKEX, SSE, SZSE, TWSE, TPEX). "
         "Tools: top_gainers, top_losers, bollinger_scan, coin_analysis, multi_agent_analysis, "
-        "volume_breakout_scanner, egx_market_overview, egx_sector_scan, and more."
+        "volume_breakout_scanner, shariah_compliance, egx_market_overview, egx_sector_scan, and more."
     ),
 )
 
@@ -626,6 +630,38 @@ def market_snapshot() -> dict:
     Powered by Yahoo Finance.
     """
     return get_market_snapshot()
+
+
+@mcp.tool()
+def check_shariah_compliance(symbol: str) -> dict:
+    """Screen a single stock for Shariah compliance using AAOIFI Standard No. 21.
+
+    Args:
+        symbol: Yahoo Finance stock ticker, such as AAPL, MSFT, THYAO.IS, or 2222.SR
+
+    Returns:
+        Full compliance report with qualitative screen, financial ratios,
+        purification rate, warnings, and informational disclaimer.
+    """
+    return screen_shariah(normalize_yahoo_symbol(symbol))
+
+
+@mcp.tool()
+def check_shariah_compliance_bulk(symbols: str) -> dict:
+    """Screen up to 20 stocks for Shariah compliance using AAOIFI Standard No. 21.
+
+    Args:
+        symbols: Comma-separated Yahoo Finance tickers, such as AAPL,MSFT,JPM,TSLA
+
+    Returns:
+        Summary counts and one compliance report per symbol.
+    """
+    symbol_list = [
+        normalize_yahoo_symbol(symbol)
+        for symbol in symbols.split(",")
+        if symbol.strip()
+    ]
+    return screen_shariah_bulk(symbol_list)
 
 
 @mcp.tool()

--- a/tests/unit/test_shariah_service.py
+++ b/tests/unit/test_shariah_service.py
@@ -1,0 +1,416 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from tradingview_mcp.core.services import shariah_service
+from tradingview_mcp.core.services.shariah_service import (
+    DEBT_THRESHOLD,
+    _purification_rate,
+    _qualitative_screen,
+    _quantitative_screen,
+    _safe_float,
+    screen_shariah,
+    screen_shariah_bulk,
+)
+
+
+def _raw(value: float) -> dict:
+    return {"raw": value, "fmt": str(value)}
+
+
+def _make_quote_summary(
+    long_name: str = "Test Corp",
+    sector: str = "Technology",
+    industry: str = "Software-Application",
+    market_cap: float = 3_000_000_000_000,
+    total_debt: float = 500_000_000_000,
+    total_cash: float = 200_000_000_000,
+    total_revenue: float = 400_000_000_000,
+    quote_type: str = "EQUITY",
+) -> dict:
+    return {
+        "assetProfile": {
+            "sector": sector,
+            "industry": industry,
+            "longBusinessSummary": f"{long_name} makes software.",
+        },
+        "price": {
+            "longName": long_name,
+            "shortName": long_name,
+            "marketCap": _raw(market_cap),
+            "quoteType": quote_type,
+        },
+        "financialData": {
+            "totalDebt": _raw(total_debt),
+            "totalCash": _raw(total_cash),
+            "totalRevenue": _raw(total_revenue),
+        },
+    }
+
+
+def _make_timeseries(
+    total_debt: float = 500_000_000_000,
+    cash_and_securities: float = 200_000_000_000,
+    receivables: float = 100_000_000_000,
+    total_revenue: float = 400_000_000_000,
+    interest_income: float = 1_000_000_000,
+    include_interest_income: bool = True,
+    interest_income_nan: bool = False,
+    revenue_date: str = "2025-12-31",
+    interest_date: str | None = "2025-12-31",
+) -> dict:
+    def item(type_name: str, value: float, date: str) -> dict:
+        return {
+            "meta": {"type": [type_name]},
+            type_name: [
+                {
+                    "asOfDate": date,
+                    "reportedValue": _raw(value),
+                }
+            ],
+        }
+
+    result = [
+        item("annualTotalDebt", total_debt, revenue_date),
+        item(
+            "annualCashCashEquivalentsAndShortTermInvestments",
+            cash_and_securities,
+            revenue_date,
+        ),
+        item("annualAccountsReceivable", receivables, revenue_date),
+        item("annualTotalRevenue", total_revenue, revenue_date),
+    ]
+    if include_interest_income:
+        result.append(
+            item(
+                "annualInterestIncome",
+                float("nan") if interest_income_nan else interest_income,
+                interest_date or revenue_date,
+            )
+        )
+    return {"result": result}
+
+
+def _mock_yahoo(monkeypatch, quote_summary: dict | None = None, timeseries: dict | None = None):
+    monkeypatch.setattr(
+        shariah_service,
+        "_fetch_quote_summary",
+        MagicMock(return_value=quote_summary or _make_quote_summary()),
+    )
+    monkeypatch.setattr(
+        shariah_service,
+        "_fetch_timeseries",
+        MagicMock(return_value=timeseries or _make_timeseries()),
+    )
+
+
+def test_safe_float_handles_missing_and_invalid_values():
+    assert _safe_float(3.14) == pytest.approx(3.14)
+    assert _safe_float(None) == 0.0
+    assert _safe_float(float("nan")) == 0.0
+    assert _safe_float("N/A") == 0.0
+
+
+def test_qualitative_screen_passes_clean_technology_company():
+    passed, reason = _qualitative_screen(
+        "Technology",
+        "Software-Application",
+        "Builds cloud software.",
+    )
+
+    assert passed is True
+    assert reason == ""
+
+
+def test_qualitative_screen_fails_prohibited_industry():
+    passed, reason = _qualitative_screen(
+        "Financial Services",
+        "Banks-Regional",
+        "Regional bank.",
+    )
+
+    assert passed is False
+    assert "prohibited" in reason.lower()
+
+
+def test_qualitative_screen_allows_video_gaming_industry():
+    passed, reason = _qualitative_screen(
+        "Communication Services",
+        "Electronic Gaming & Multimedia",
+        "Video game developer.",
+    )
+
+    assert passed is True
+    assert reason == ""
+
+
+def test_qualitative_screen_ignores_broad_credit_word_in_description():
+    passed, reason = _qualitative_screen(
+        "Technology",
+        "Consumer Electronics",
+        "The company offers payment, credit, and cloud services.",
+    )
+
+    assert passed is True
+    assert reason == ""
+
+
+def test_qualitative_screen_allows_non_alcoholic_beverages():
+    passed, reason = _qualitative_screen(
+        "Consumer Defensive",
+        "Beverages - Non-Alcoholic",
+        "The company makes nonalcoholic beverages, soft drinks, and bottled water.",
+    )
+
+    assert passed is True
+    assert reason == ""
+
+
+def test_qualitative_screen_fails_brewers_with_spaced_industry_hyphen():
+    passed, reason = _qualitative_screen(
+        "Consumer Defensive",
+        "Beverages - Brewers",
+        "The company produces beer.",
+    )
+
+    assert passed is False
+    assert "prohibited" in reason.lower()
+
+
+def test_qualitative_screen_fails_explicit_description_prohibited_activity():
+    passed, reason = _qualitative_screen(
+        "Consumer Cyclical",
+        "Entertainment",
+        "The company operates casino and sports betting platforms.",
+    )
+
+    assert passed is False
+    assert "prohibited" in reason.lower()
+
+
+def test_quantitative_screen_requires_all_ratios_below_threshold():
+    passed, debt, cash, receivables, failed = _quantitative_screen(
+        market_cap=1_000_000,
+        total_debt=100_000,
+        cash_and_securities=50_000,
+        accounts_receivable=80_000,
+    )
+
+    assert passed is True
+    assert debt == pytest.approx(0.1)
+    assert cash == pytest.approx(0.05)
+    assert receivables == pytest.approx(0.08)
+    assert failed == []
+
+
+def test_quantitative_screen_fails_at_threshold_boundary():
+    threshold_value = int(1_000_000 * DEBT_THRESHOLD)
+
+    passed, _, _, _, failed = _quantitative_screen(
+        market_cap=1_000_000,
+        total_debt=threshold_value,
+        cash_and_securities=threshold_value,
+        accounts_receivable=threshold_value,
+    )
+
+    assert passed is False
+    assert len(failed) == 3
+    assert all("30% threshold" in item for item in failed)
+
+
+def test_quantitative_screen_passes_just_below_30_percent_threshold():
+    passed, debt, cash, receivables, failed = _quantitative_screen(
+        market_cap=1_000_000,
+        total_debt=299_999,
+        cash_and_securities=299_999,
+        accounts_receivable=299_999,
+    )
+
+    assert passed is True
+    assert debt == pytest.approx(0.299999)
+    assert cash == pytest.approx(0.299999)
+    assert receivables == pytest.approx(0.299999)
+    assert failed == []
+
+
+def test_quantitative_screen_fails_without_market_cap():
+    passed, _, _, _, failed = _quantitative_screen(0, 0, 0, 0)
+
+    assert passed is False
+    assert any("market cap" in item.lower() for item in failed)
+
+
+def test_purification_rate_is_interest_income_over_revenue():
+    assert _purification_rate(1_000_000, 100_000_000) == pytest.approx(0.01)
+    assert _purification_rate(0, 100_000_000) == 0.0
+    assert _purification_rate(100, 0) == 0.0
+    assert _purification_rate(999_999_999, 1) == 1.0
+
+
+def test_screen_shariah_returns_compliant_report(monkeypatch):
+    _mock_yahoo(monkeypatch)
+
+    result = screen_shariah(" aapl ")
+
+    assert result["symbol"] == "AAPL"
+    assert result["status"] == "halal"
+    assert result["compliant"] is True
+    assert result["methodology"] == "AAOIFI Standard No. 21"
+    assert result["purification"]["rate"] == "0.25%"
+    assert result["purification"]["available"] is True
+
+
+def test_screen_shariah_uses_financial_data_fallbacks(monkeypatch):
+    _mock_yahoo(monkeypatch, timeseries={"result": []})
+
+    result = screen_shariah("AAPL")
+
+    assert result["symbol"] == "AAPL"
+    assert result["raw_financials"]["total_debt"] == 500_000_000_000
+    assert result["raw_financials"]["cash_and_securities"] == 200_000_000_000
+    assert result["purification"]["available"] is False
+    assert result["warnings"]
+
+
+def test_screen_shariah_validates_empty_symbol():
+    result = screen_shariah("  ")
+
+    assert result == {"error": "No symbol provided."}
+
+
+def test_screen_shariah_handles_yahoo_fetch_error(monkeypatch):
+    monkeypatch.setattr(
+        shariah_service,
+        "_fetch_quote_summary",
+        MagicMock(side_effect=Exception("Yahoo unavailable")),
+    )
+
+    result = screen_shariah("AAPL")
+
+    assert result["symbol"] == "AAPL"
+    assert "Yahoo unavailable" in result["error"]
+    assert "disclaimer" in result
+
+
+def test_screen_shariah_rejects_non_equity_quote_types(monkeypatch):
+    _mock_yahoo(monkeypatch, quote_summary=_make_quote_summary(quote_type="ETF"))
+
+    result = screen_shariah("SPY")
+
+    assert result["symbol"] == "SPY"
+    assert result["quote_type"] == "ETF"
+    assert "individual equities" in result["error"]
+    assert result["verdict"] == "UNABLE TO SCREEN"
+
+
+def test_screen_shariah_fails_prohibited_business_activity(monkeypatch):
+    _mock_yahoo(
+        monkeypatch,
+        quote_summary=_make_quote_summary(
+            sector="Financial Services",
+            industry="Banks-Regional",
+        ),
+    )
+
+    result = screen_shariah("JPM")
+
+    assert result["status"] == "haram"
+    assert result["compliant"] is False
+    assert result["screening"]["qualitative_screen"]["status"] == "FAILED"
+
+
+def test_screen_shariah_handles_statement_fetch_warnings(monkeypatch):
+    _mock_yahoo(monkeypatch, timeseries={"result": []})
+
+    result = screen_shariah("ERR")
+
+    assert result["symbol"] == "ERR"
+    assert result["warnings"]
+
+
+def test_screen_shariah_marks_purification_unavailable_when_interest_income_missing(monkeypatch):
+    _mock_yahoo(monkeypatch, timeseries=_make_timeseries(include_interest_income=False))
+
+    result = screen_shariah("AAPL")
+
+    assert result["status"] == "halal"
+    assert result["purification"]["available"] is False
+    assert "unavailable" in result["purification"]["note"].lower()
+    assert "purification data unavailable" in result["verdict"].lower()
+
+
+def test_screen_shariah_marks_purification_unavailable_when_interest_income_nan(monkeypatch):
+    _mock_yahoo(monkeypatch, timeseries=_make_timeseries(interest_income_nan=True))
+
+    result = screen_shariah("AAPL")
+
+    assert result["status"] == "halal"
+    assert result["purification"]["available"] is False
+    assert "unavailable" in result["purification"]["note"].lower()
+
+
+def test_screen_shariah_marks_purification_unavailable_when_periods_mismatch(monkeypatch):
+    _mock_yahoo(
+        monkeypatch,
+        timeseries=_make_timeseries(revenue_date="2025-12-31", interest_date="2024-12-31"),
+    )
+
+    result = screen_shariah("AAPL")
+
+    assert result["status"] == "halal"
+    assert result["purification"]["available"] is False
+    assert "unavailable" in result["purification"]["note"].lower()
+
+
+def test_screen_shariah_bulk_summarizes_results(monkeypatch):
+    mock_screen = MagicMock(
+        side_effect=[
+            {"symbol": "AAPL", "compliant": True},
+            {"symbol": "JPM", "compliant": False},
+            {"symbol": "BAD", "error": "not found"},
+        ]
+    )
+    monkeypatch.setattr(shariah_service, "screen_shariah", mock_screen)
+
+    result = screen_shariah_bulk(["AAPL", "JPM", "BAD"])
+
+    assert result["summary"]["total_screened"] == 3
+    assert result["summary"]["halal"] == 1
+    assert result["summary"]["haram"] == 1
+    assert result["summary"]["halal_list"] == ["AAPL"]
+    assert result["summary"]["haram_list"] == ["JPM"]
+    assert result["summary"]["compliant"] == 1
+    assert result["summary"]["non_compliant"] == 1
+    assert result["summary"]["compliant_list"] == ["AAPL"]
+    assert result["summary"]["non_compliant_list"] == ["JPM"]
+    assert result["summary"]["errors"] == 1
+    assert result["summary"]["error_list"] == ["BAD"]
+
+
+def test_screen_shariah_bulk_validates_request_size():
+    assert "error" in screen_shariah_bulk([])
+    assert "20" in screen_shariah_bulk([f"SYM{i}" for i in range(21)])["error"]
+
+
+def test_server_bulk_tool_parses_and_normalizes_symbols(monkeypatch):
+    from tradingview_mcp import server
+
+    mock_bulk = MagicMock(return_value={"ok": True})
+    monkeypatch.setattr(server, "screen_shariah_bulk", mock_bulk)
+
+    result = server.check_shariah_compliance_bulk(" aapl, twse:taiex, , msft ")
+
+    assert result == {"ok": True}
+    mock_bulk.assert_called_once_with(["AAPL", "^TWII", "MSFT"])
+
+
+def test_server_single_tool_normalizes_symbol(monkeypatch):
+    from tradingview_mcp import server
+
+    mock_screen = MagicMock(return_value={"status": "halal"})
+    monkeypatch.setattr(server, "screen_shariah", mock_screen)
+
+    result = server.check_shariah_compliance(" twse:taiex ")
+
+    assert result == {"status": "halal"}
+    mock_screen.assert_called_once_with("^TWII")


### PR DESCRIPTION
## Summary

Adds Shariah compliance screening tools for individual equities using AAOIFI-style screening.

New MCP tools:
- `check_shariah_compliance`
- `check_shariah_compliance_bulk`

## Details

The screen performs:
- Qualitative business activity checks for prohibited sectors/industries
- Quantitative ratio checks with a 30% threshold:
  - debt / market cap
  - cash and securities / market cap
  - receivables / market cap
- Purification rate calculation when matching-period interest income data is available
- `halal` / `haram` status output
- Clear `UNABLE TO SCREEN` response for unsupported quote types such as ETFs

The implementation uses Yahoo Finance public JSON endpoints directly, matching the existing project style and avoiding a new heavy dependency.

## Tests

```bash
uv run pytest tests/unit -q