### PR TITLE
feat(cache): generic TTL cache + wrap 5 read-only services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,28 @@ PROXY_SESSION_MAX=250
 
 # Set to false to disable proxy entirely
 PROXY_ENABLED=true
+
+# ── TradingView session cookie (Optional but HIGH-LEVERAGE) ───
+# Authenticated (logged-in) scanner requests get far higher rate limits than
+# anonymous scraping — this is the root-cause fix for the daily empty-body
+# ("Expecting value: line 1 column 1") outage on scanner.tradingview.com.
+#
+# How to grab it (must be logged in to TradingView in your browser):
+#   1. DevTools -> Application/Storage -> Cookies -> https://www.tradingview.com
+#   2. Copy the values of  sessionid  and  sessionid_sign
+#   3. Paste as a single cookie header below (semicolon-separated).
+# Cookies expire periodically — refresh when scans start failing again.
+TRADINGVIEW_COOKIE=sessionid=PASTE_HERE; sessionid_sign=PASTE_HERE
+
+# ── Scanner resilience tunables (Optional) ────────────────────
+# Fast-fail: comma-separated retry backoffs (sec). "1,3" = ~4s to bail vs ~53s.
+TRADINGVIEW_MCP_RETRY_DELAYS=1,3
+# Circuit breaker: after retries exhaust, fail fast (raise) instead of hitting
+# the endpoint for N sec, rather than re-walking the ladder every call
+# (0 = breaker off). Renamed from TRADINGVIEW_MCP_FAILURE_COOLDOWN_S, which now
+# belongs to upstream's sleep-before-retry cooldown (default 15s).
+TRADINGVIEW_MCP_CIRCUIT_COOLDOWN_S=20
+# Brief success cache + in-flight throttle (already honored by the server).
+TRADINGVIEW_MCP_CACHE_TTL=120
+TRADINGVIEW_MCP_MAX_INFLIGHT=2
+TRADINGVIEW_MCP_MIN_INTERVAL_S=1.5

--- a/.gitignore
+++ b/.gitignore
@@ -230,6 +230,7 @@ test_*.py
 # Internal strategy docs — not for public repo
 LAUNCH_STRATEGY.md
 RELEASE_NOTES_*.md
+ROADMAP.md
 
 # Scratch / temp files
 Untitled-*

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ https://github-production-user-asset-6210df.s3.amazonaws.com/67838093/478689497-
 **Stability & Strategy Expansion (May 2026)**
 
 - **9 backtest strategies** (up from 6) — added `rsi_pullback`, `keltner_breakout`, and `triple_ema`, covering trend-pullback, ATR-normalized breakout, and SMA200-filtered EMA cross edges. `compare_strategies` now ranks the full 9.
+- **Generic per-tool TTL cache** — `yahoo_price`, `extended_hours`, `financial_news`, `sentiment`, and both options tools no longer re-issue HTTP on every call. Per-tool TTLs are env-tunable (`CACHE_TTL_YAHOO_PRICE`, `CACHE_TTL_NEWS`, etc. — see [Caching & throttle env vars](#caching--throttle-env-vars)). Error responses are not cached, so transient upstream failures aren't memoized. *(PR [#43](https://github.com/atilaahmettaner/tradingview-mcp/pull/43) — open)*
 - **Resilience layer** — automatic retry + 60-second TTL cache on the TradingView screener provider, eliminating transient `"Expecting value"` errors on `combined_analysis` and `multi_timeframe_analysis`. *(PR [#32](https://github.com/atilaahmettaner/tradingview-mcp/pull/32) — merged)*
 - **Financial news service rebuild** — replaces deprecated Reuters RSS endpoints with Yahoo Finance, MarketWatch, and CNBC. Fixes the long-standing `count: 0` bug on `financial_news`. *(PR [#33](https://github.com/atilaahmettaner/tradingview-mcp/pull/33) — merged)*
 - **TA throttle** — caps concurrent `tradingview_ta` calls (default 4) + min 0.8s spacing between starts. Prevents parallel bursts of `combined_analysis` / `multi_timeframe_analysis` from hitting TradingView's empty-body rate-limit cliff. Tunable via env vars. *(PR [#34](https://github.com/atilaahmettaner/tradingview-mcp/pull/34) — merged)*
@@ -197,6 +198,56 @@ else:
 ```
 
 Stable codes are defined in [`core/errors.py`](src/tradingview_mcp/core/errors.py).
+
+---
+
+## ⚙️ Caching & throttle env vars
+
+All env vars are optional — sensible defaults apply when unset. Set any cache TTL to `0` to disable that tool's cache at runtime.
+
+**Per-tool TTL cache** (`@cached` decorator, in seconds):
+
+| Env var | Default | Tool |
+| --- | --- | --- |
+| `CACHE_TTL_YAHOO_PRICE` | 30 | `yahoo_price` |
+| `CACHE_TTL_EXTENDED_HOURS` | 30 | `stock_extended_hours` |
+| `CACHE_TTL_OPTIONS_CHAIN` | 60 | `stock_options_chain` |
+| `CACHE_TTL_OPTIONS_UNUSUAL` | 60 | `stock_options_unusual_activity` |
+| `CACHE_TTL_NEWS` | 300 | `financial_news` |
+| `CACHE_TTL_SENTIMENT` | 300 | `analyze_sentiment` |
+
+Error responses (`{"error": ...}` envelopes) are **not** cached, so transient upstream failures don't get memoized for the TTL window.
+
+**Screener resilience layer** (shared by `combined_analysis`, `multi_timeframe_analysis`, EGX/scanner tools):
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `TRADINGVIEW_MCP_CACHE_TTL` | 60 | TTL for the screener provider's shared cache (seconds) |
+| `TRADINGVIEW_MCP_RETRY_DELAYS` | `0.5,1.5,4.0` | Comma-separated backoff between retries on transient errors |
+
+**TA throttle** (caps parallel `tradingview_ta` calls):
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `TRADINGVIEW_MCP_MAX_INFLIGHT` | 4 | Max concurrent TA calls |
+| `TRADINGVIEW_MCP_MIN_INTERVAL_S` | 0.8 | Min seconds between TA call starts |
+
+Set in `claude_desktop_config.json` via the `env` key:
+
+```json
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "--from", "tradingview-mcp-server", "tradingview-mcp"],
+      "env": {
+        "CACHE_TTL_YAHOO_PRICE": "60",
+        "CACHE_TTL_NEWS": "600"
+      }
+    }
+  }
+}
+```
 
 ---
 
@@ -440,6 +491,7 @@ Every sponsor directly funds new features like Walk-Forward Backtesting, Twitter
 - [x] Backtesting engine (9 strategies + Sharpe / Calmar / Expectancy)
 - [x] Walk-forward backtesting (overfitting detection)
 - [x] Resilience layer (retry + TTL cache) on screener provider
+- [x] Per-tool TTL cache on Yahoo / news / sentiment / options (env-tunable, error-aware)
 - [x] Hourly (1h) backtesting timeframe
 - [ ] Twitter/X market sentiment
 - [ ] Paper trading simulation

--- a/src/tradingview_mcp/core/services/extended_hours_service.py
+++ b/src/tradingview_mcp/core/services/extended_hours_service.py
@@ -29,9 +29,15 @@ import urllib.request
 import urllib.error
 from typing import Optional
 
+from tradingview_mcp.core.utils.cache import cached
+
 _TIMEOUT = 12
 _UA = "tradingview-mcp/0.8.1"
 _BASE = "https://query1.finance.yahoo.com/v8/finance/chart"
+
+
+def _is_error_result(r: object) -> bool:
+    return isinstance(r, dict) and "error" in r
 
 
 def _change_pct(price: Optional[float], reference: Optional[float]) -> Optional[float]:
@@ -47,6 +53,12 @@ def _fmt_time(ts: Optional[int]) -> Optional[str]:
     return time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(ts))
 
 
+@cached(
+    key_fn=lambda symbol: symbol.upper(),
+    ttl_env="CACHE_TTL_EXTENDED_HOURS",
+    default_ttl=30.0,
+    cache_unless=_is_error_result,
+)
 def get_extended_hours_price(symbol: str) -> dict:
     """Fetch latest pre-market, regular-session, and post-market prices.
 

--- a/src/tradingview_mcp/core/services/news_service.py
+++ b/src/tradingview_mcp/core/services/news_service.py
@@ -19,12 +19,24 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
+from tradingview_mcp.core.utils.cache import cached
+
 # feedparser is bundled with agent-reach (installed globally)
 try:
     import feedparser
     _FEEDPARSER_AVAILABLE = True
 except ImportError:
     _FEEDPARSER_AVAILABLE = False
+
+
+def _is_news_error(items: object) -> bool:
+    """Skip caching when feedparser is missing (returns error sentinel list)."""
+    return (
+        isinstance(items, list)
+        and len(items) == 1
+        and isinstance(items[0], dict)
+        and "error" in items[0]
+    )
 
 # ─── Feed Catalog ─────────────────────────────────────────────────────────────
 
@@ -56,6 +68,16 @@ _TIMEOUT = 8
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 
+@cached(
+    key_fn=lambda symbol=None, category="stocks", limit=10: (
+        (symbol or "").upper(),
+        category,
+        int(limit),
+    ),
+    ttl_env="CACHE_TTL_NEWS",
+    default_ttl=300.0,
+    cache_unless=_is_news_error,
+)
 def fetch_news(
     symbol: Optional[str] = None,
     category: str = "stocks",

--- a/src/tradingview_mcp/core/services/options_service.py
+++ b/src/tradingview_mcp/core/services/options_service.py
@@ -38,11 +38,17 @@ import urllib.request
 import urllib.error
 from typing import Optional, List, Dict, Any
 
+from tradingview_mcp.core.utils.cache import cached
+
 _TIMEOUT = 12
 _UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 )
+
+
+def _is_error_result(r: object) -> bool:
+    return isinstance(r, dict) and "error" in r
 # Yahoo started gating /v7/finance/options behind a crumb+cookie session
 # in 2024 (same as the quoteSummary endpoint). Without auth: HTTP 401.
 # We open a session against fc.yahoo.com to drop cookies, then ask
@@ -161,6 +167,12 @@ def _normalize_contract(c: Dict[str, Any], side: str) -> Dict[str, Any]:
 # ── Tool 1: get_options_chain ───────────────────────────────────────────────
 
 
+@cached(
+    key_fn=lambda symbol, expiry=None: (symbol.strip().upper(), expiry or ""),
+    ttl_env="CACHE_TTL_OPTIONS_CHAIN",
+    default_ttl=60.0,
+    cache_unless=_is_error_result,
+)
 def get_options_chain(symbol: str, expiry: Optional[str] = None) -> dict:
     """Fetch options chain (calls + puts) for one symbol and one expiry.
 
@@ -249,6 +261,17 @@ def get_options_chain(symbol: str, expiry: Optional[str] = None) -> dict:
 # ── Tool 2: get_unusual_options_activity ────────────────────────────────────
 
 
+@cached(
+    key_fn=lambda symbol, top_n=10, min_volume=100, expiries=4: (
+        symbol.strip().upper(),
+        int(top_n),
+        int(min_volume),
+        int(expiries),
+    ),
+    ttl_env="CACHE_TTL_OPTIONS_UNUSUAL",
+    default_ttl=60.0,
+    cache_unless=_is_error_result,
+)
 def get_unusual_options_activity(
     symbol: str,
     top_n: int = 10,

--- a/src/tradingview_mcp/core/services/screener_provider.py
+++ b/src/tradingview_mcp/core/services/screener_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import List, Dict, Any, Optional, Tuple
+from ..utils.cache import MISS as _CACHE_MISS, TTLCache as _TTLCache
 from ..utils.validators import get_market_type
 import json as _json
 import os as _os
@@ -7,7 +8,7 @@ import random as _random
 import socket as _socket
 import sys as _sys
 import time as _time
-from threading import RLock as _RLock, Semaphore as _Semaphore, Lock as _Lock
+from threading import Semaphore as _Semaphore, Lock as _Lock
 
 
 # --- Socket-level timeout (added 2026-05-20) ------------------------------
@@ -326,43 +327,24 @@ def _circuit_record(success: bool) -> None:
         _CIRCUIT_OPEN_UNTIL = 0.0 if success else (_time.time() + _circuit_cooldown_s())
 
 
-_SCREENER_CACHE: Dict[Tuple, Tuple[float, Any]] = {}
-_SCREENER_CACHE_LOCK = _RLock()
+# Shared TTLCache instance for all screener/TA calls. The cache itself is
+# TTL-agnostic; ``_cache_get`` passes the current ``TRADINGVIEW_MCP_CACHE_TTL``
+# on each call so env changes take effect immediately. A fresh-TTL miss does
+# NOT evict the entry — the stale lookup below may still want it.
+_SCREENER_CACHE = _TTLCache()
 
 
 def _cache_get(key: Tuple):
     """Return cached payload if fresh (within TRADINGVIEW_MCP_CACHE_TTL)."""
-    ttl = _cache_ttl_s()
-    if ttl <= 0:
-        return None
-    with _SCREENER_CACHE_LOCK:
-        entry = _SCREENER_CACHE.get(key)
-        if not entry:
-            return None
-        ts, payload = entry
-        if _time.time() - ts > ttl:
-            # Don't pop here — stale lookup below may still want it.
-            return None
-        return payload
+    payload = _SCREENER_CACHE.get(key, _cache_ttl_s())
+    return None if payload is _CACHE_MISS else payload
 
 
 def _cache_get_stale(key: Tuple) -> Optional[Tuple[float, Any]]:
     """Return (age_seconds, payload) if a stale-but-usable entry exists
     (older than fresh TTL, younger than stale TTL). Used as last-resort
     fallback when fresh upstream fetch fails persistently."""
-    stale_ttl = _stale_ttl_s()
-    if stale_ttl <= 0:
-        return None
-    with _SCREENER_CACHE_LOCK:
-        entry = _SCREENER_CACHE.get(key)
-        if not entry:
-            return None
-        ts, payload = entry
-        age = _time.time() - ts
-        if age > stale_ttl:
-            _SCREENER_CACHE.pop(key, None)
-            return None
-        return (age, payload)
+    return _SCREENER_CACHE.get_with_age(key, _stale_ttl_s())
 
 
 def _cache_set(key: Tuple, payload: Any) -> None:
@@ -372,8 +354,7 @@ def _cache_set(key: Tuple, payload: Any) -> None:
     fresh_ttl = _cache_ttl_s()
     if stale_ttl <= 0 and fresh_ttl <= 0:
         return
-    with _SCREENER_CACHE_LOCK:
-        _SCREENER_CACHE[key] = (_time.time(), payload)
+    _SCREENER_CACHE.set(key, payload)
 
 
 # --- Throttle for tradingview_ta calls (added 2026-05-15) -----------------

--- a/src/tradingview_mcp/core/services/screener_provider.py
+++ b/src/tradingview_mcp/core/services/screener_provider.py
@@ -239,6 +239,56 @@ def _tv_proxies():
         return None
 
 
+_BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+)
+
+
+class _AuthRequestsShim:
+    """Proxies the real ``requests`` module but injects the TradingView session
+    cookie + a browser User-Agent into ``.post()`` calls. tradingview_ta (Path A,
+    get_multiple_analysis / TA_Handler) hits the SAME scanner.tradingview.com
+    endpoint as the screener but exposes no cookie parameter and ships a bot UA
+    (``tradingview_ta/x.y.z``), so it gets anonymous-rate-limited. Replacing the
+    module-level ``requests`` reference inside tradingview_ta.main with this shim
+    makes Path A authenticated like Path B — without forking the vendored lib or
+    changing its rich Analysis output. Only tradingview_ta is affected; every
+    other module keeps its own untouched ``requests``."""
+
+    def __init__(self, real):
+        self._real = real
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def post(self, url, **kwargs):
+        cookies = _tv_cookies()
+        if cookies and not kwargs.get("cookies"):
+            kwargs["cookies"] = cookies
+        headers = dict(kwargs.get("headers") or {})
+        headers["User-Agent"] = _BROWSER_UA  # replace the self-identifying bot UA
+        kwargs["headers"] = headers
+        return self._real.post(url, **kwargs)
+
+
+def _patch_tradingview_ta_auth() -> None:
+    """Authenticate tradingview_ta's requests (cookie + browser UA) so Path A
+    stops being anonymous — the same root-cause fix already applied to the
+    screener (Path B). Idempotent; no-op if tradingview_ta isn't importable."""
+    try:
+        from tradingview_ta import main as _ta_main
+    except Exception:
+        return
+    if getattr(_ta_main, "_tvmcp_auth_patched", False):
+        return
+    try:
+        _ta_main.requests = _AuthRequestsShim(_ta_main.requests)
+        _ta_main._tvmcp_auth_patched = True
+    except Exception:
+        pass
+
+
 def _circuit_cooldown_s() -> float:
     try:
         return max(0.0, float(_os.environ.get('TRADINGVIEW_MCP_CIRCUIT_COOLDOWN_S', '0')))
@@ -494,6 +544,7 @@ def resilient_get_multiple_analysis(screener, interval, symbols):
         from tradingview_ta import get_multiple_analysis as _gma  # type: ignore
     except Exception as e:
         raise ImportError("tradingview_ta is not installed") from e
+    _patch_tradingview_ta_auth()  # Path A: authenticate via cookie + browser UA
 
     sym_key = tuple(sorted(symbols)) if symbols else ()
     cache_key = ('ta_multi_v1', screener, interval, sym_key)

--- a/src/tradingview_mcp/core/services/screener_provider.py
+++ b/src/tradingview_mcp/core/services/screener_provider.py
@@ -176,6 +176,106 @@ def _wait_for_failure_cooldown() -> None:
         _time.sleep(wait)
 
 
+# --- Auth + proxy + circuit breaker (added 2026-06-03) ---------------------
+# Root cause of the recurring daily empty-body outage: anonymous, single-IP,
+# bot-UA scraping of scanner.tradingview.com gets rate-limited (TradingView
+# returns an empty 200/429 body -> JSONDecodeError "Expecting value"). Three
+# mitigations, applied here:
+#   1. PROXY    — route requests through the (already-built) Webshare rotating
+#                 proxy so traffic isn't all from one IP.
+#   2. COOKIE   — authenticate the screener path with a logged-in TradingView
+#                 session cookie; authenticated requests get far higher limits
+#                 than anonymous scraping. (Path A / tradingview_ta can't take a
+#                 cookie, so it relies on the proxy; Path B / get_scanner_data
+#                 gets both.)
+#   3. CIRCUIT  — a fail-fast breaker that stops re-hammering a blocked
+#                 endpoint for a cooldown window instead of every call
+#                 re-walking the retry ladder and deepening the block.
+#                 (Distinct from TRADINGVIEW_MCP_FAILURE_COOLDOWN_S above,
+#                 which sleeps before retrying; the circuit raises instead.)
+#
+# Secrets live in the gitignored repo-root .env (NOT .mcp.json, which is
+# version-controlled). See .env.example:
+#   TRADINGVIEW_COOKIE   raw cookie header, e.g. "sessionid=abc; sessionid_sign=def"
+#   PROXY_USERNAME_PREFIX / PROXY_PASSWORD / PROXY_HOST  (Webshare)
+#   TRADINGVIEW_MCP_CIRCUIT_COOLDOWN_S  seconds to hold the circuit open (0=off)
+
+# Best-effort .env load so TRADINGVIEW_COOKIE is available regardless of import
+# order (proxy_manager loads the same .env at import time).
+try:
+    from dotenv import load_dotenv as _load_dotenv
+    _load_dotenv(
+        dotenv_path=_os.path.join(_os.path.dirname(__file__), "../../../../.env"),
+        override=False,
+    )
+except Exception:
+    pass
+
+
+def _tv_cookies():
+    """Parse TRADINGVIEW_COOKIE ('k=v; k2=v2') into a dict for requests, or None.
+    Logged-in requests dodge the anonymous-scraper rate limit that causes the
+    daily empty-body outage."""
+    raw = _os.environ.get('TRADINGVIEW_COOKIE', '').strip()
+    if not raw:
+        return None
+    jar: Dict[str, str] = {}
+    for part in raw.split(';'):
+        part = part.strip()
+        if not part or '=' not in part:
+            continue
+        k, v = part.split('=', 1)
+        jar[k.strip()] = v.strip()
+    return jar or None
+
+
+def _tv_proxies():
+    """requests-style proxies dict from the Webshare proxy manager, or None if
+    not configured. Rotating IPs sidestep per-IP rate limiting."""
+    try:
+        from .proxy_manager import get_proxy
+        return get_proxy()
+    except Exception:
+        return None
+
+
+def _circuit_cooldown_s() -> float:
+    try:
+        return max(0.0, float(_os.environ.get('TRADINGVIEW_MCP_CIRCUIT_COOLDOWN_S', '0')))
+    except Exception:
+        return 0.0
+
+
+_CIRCUIT_LOCK = _Lock()
+_CIRCUIT_OPEN_UNTIL: float = 0.0
+
+
+class ScreenerCircuitOpen(RuntimeError):
+    """Raised when the scanner circuit breaker is open (endpoint recently
+    failing). Surfaced fast to callers so a scan degrades instead of grinding."""
+
+
+def _circuit_check() -> None:
+    """Raise immediately if the circuit is open, instead of hammering a
+    known-blocked endpoint and deepening the block. No-op when cooldown=0."""
+    if _circuit_cooldown_s() <= 0:
+        return
+    with _CIRCUIT_LOCK:
+        remaining = _CIRCUIT_OPEN_UNTIL - _time.time()
+    if remaining > 0:
+        raise ScreenerCircuitOpen(
+            f"scanner circuit open ~{remaining:.0f}s (endpoint rate-limited); failing fast"
+        )
+
+
+def _circuit_record(success: bool) -> None:
+    if _circuit_cooldown_s() <= 0:
+        return
+    global _CIRCUIT_OPEN_UNTIL
+    with _CIRCUIT_LOCK:
+        _CIRCUIT_OPEN_UNTIL = 0.0 if success else (_time.time() + _circuit_cooldown_s())
+
+
 _SCREENER_CACHE: Dict[Tuple, Tuple[float, Any]] = {}
 _SCREENER_CACHE_LOCK = _RLock()
 
@@ -313,13 +413,28 @@ def _format_transient_error(last_exc: BaseException, attempts: int, total_wait: 
     )
 
 
-def _scan_with_retry(q, cookies=None, cache_key: Optional[Tuple] = None):
+def _scan_with_retry(q, cookies=None, proxies=None, cache_key: Optional[Tuple] = None):
     """Wrap Query.get_scanner_data with retries on transient TV outages.
+    Self-configures the TradingView session cookie + Webshare proxy from env
+    when not explicitly supplied, and honors the fail-fast circuit breaker.
     Returns (total, df). Re-raises on non-transient errors or on final failure.
 
     If ``cache_key`` is provided and all retries fail, attempts to return a
     stale-but-usable cached payload before raising — callers that pass a key
     get stale-while-error behavior automatically."""
+    if cookies is None:
+        cookies = _tv_cookies()
+    if proxies is None:
+        proxies = _tv_proxies()
+    try:
+        _circuit_check()  # fail fast if the endpoint is in a cooldown window
+    except ScreenerCircuitOpen:
+        # Degrade to stale data instead of raising when we can.
+        if cache_key is not None:
+            stale = _cache_get_stale(cache_key)
+            if stale is not None:
+                return stale[1]
+        raise
     _wait_for_failure_cooldown()
     delays = (0.0,) + _retry_delays()  # immediate try, then back off
     last_exc: Optional[BaseException] = None
@@ -330,7 +445,9 @@ def _scan_with_retry(q, cookies=None, cache_key: Optional[Tuple] = None):
             _time.sleep(wait)
             total_wait += wait
         try:
-            return q.get_scanner_data(cookies=cookies)
+            result = q.get_scanner_data(cookies=cookies, proxies=proxies)
+            _circuit_record(True)
+            return result
         except Exception as e:  # noqa: BLE001 - intentionally broad, narrowed below
             if not _is_transient_screener_error(e):
                 raise
@@ -344,8 +461,10 @@ def _scan_with_retry(q, cookies=None, cache_key: Optional[Tuple] = None):
             except Exception:
                 pass
             continue
-    # All attempts exhausted — record failure so subsequent calls back off
+    # All attempts exhausted — record failure so subsequent calls back off,
+    # and open the circuit so we stop hammering a blocked endpoint.
     _record_ta_failure()
+    _circuit_record(False)
     # Last-resort: stale-while-error fallback if we have a cache key
     if cache_key is not None:
         stale = _cache_get_stale(cache_key)
@@ -382,7 +501,16 @@ def resilient_get_multiple_analysis(screener, interval, symbols):
     if cached is not None:
         return cached
 
+    try:
+        _circuit_check()  # fail fast if the endpoint is in a cooldown window
+    except ScreenerCircuitOpen:
+        # Degrade to stale data instead of raising when we can.
+        stale = _cache_get_stale(cache_key)
+        if stale is not None:
+            return stale[1]
+        raise
     _wait_for_failure_cooldown()
+    proxies = _tv_proxies()  # tradingview_ta has no cookie param; proxy-protect it
     delays = (0.0,) + _retry_delays()
     last_exc: Optional[BaseException] = None
     total_wait = 0.0
@@ -402,10 +530,12 @@ def resilient_get_multiple_analysis(screener, interval, symbols):
                     interval=interval,
                     symbols=symbols,
                     timeout=_socket_timeout_s(),
+                    proxies=proxies,
                 )
             finally:
                 _ta_throttle_release()
             _cache_set(cache_key, result)
+            _circuit_record(True)
             return result
         except Exception as e:  # noqa: BLE001
             if not _is_transient_screener_error(e):
@@ -420,8 +550,10 @@ def resilient_get_multiple_analysis(screener, interval, symbols):
             except Exception:
                 pass
             continue
-    # All attempts exhausted — record failure so subsequent calls back off
+    # All attempts exhausted — record failure so subsequent calls back off,
+    # and open the circuit so we stop hammering a blocked endpoint.
     _record_ta_failure()
+    _circuit_record(False)
     # Last-resort: stale-while-error fallback (up to TRADINGVIEW_MCP_STALE_TTL)
     stale = _cache_get_stale(cache_key)
     if stale is not None:
@@ -504,7 +636,10 @@ def fetch_atr_for_tickers(
         "columns": [col],
     }
     try:
-        resp = requests.post(url, json=payload, timeout=timeout)
+        resp = requests.post(
+            url, json=payload, timeout=timeout,
+            proxies=_tv_proxies(), cookies=_tv_cookies(),
+        )
         resp.raise_for_status()
         body = resp.json()
     except Exception:  # noqa: BLE001 — graceful degrade

--- a/src/tradingview_mcp/core/services/sentiment_service.py
+++ b/src/tradingview_mcp/core/services/sentiment_service.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from tradingview_mcp.core.services.proxy_manager import build_opener_with_proxy, is_proxy_configured
+from tradingview_mcp.core.utils.cache import cached
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -89,6 +90,15 @@ def _label(score: float) -> str:
 
 # ─── Public API ───────────────────────────────────────────────────────────────
 
+@cached(
+    key_fn=lambda symbol, category="all", limit=20: (
+        symbol.upper(),
+        category,
+        int(limit),
+    ),
+    ttl_env="CACHE_TTL_SENTIMENT",
+    default_ttl=300.0,
+)
 def analyze_sentiment(
     symbol: str,
     category: str = "all",

--- a/src/tradingview_mcp/core/services/yahoo_finance_service.py
+++ b/src/tradingview_mcp/core/services/yahoo_finance_service.py
@@ -20,10 +20,16 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from tradingview_mcp.core.services.proxy_manager import build_opener_with_proxy
+from tradingview_mcp.core.utils.cache import cached
 
 _TIMEOUT = 12
 _UA = "tradingview-mcp/0.5.0"
 _BASE = "https://query1.finance.yahoo.com/v8/finance/chart"
+
+
+def _is_error_result(r: object) -> bool:
+    """Predicate: skip caching when Yahoo returned an error envelope."""
+    return isinstance(r, dict) and "error" in r
 
 
 def _fetch_quote(symbol: str) -> dict:
@@ -59,6 +65,12 @@ def _get_previous_close(chart_result: dict) -> Optional[float]:
     return meta.get("previousClose") or meta.get("chartPreviousClose")
 
 
+@cached(
+    key_fn=lambda symbol: symbol.upper(),
+    ttl_env="CACHE_TTL_YAHOO_PRICE",
+    default_ttl=30.0,
+    cache_unless=_is_error_result,
+)
 def get_price(symbol: str) -> dict:
     """
     Get real-time price data for any Yahoo Finance symbol.

--- a/src/tradingview_mcp/core/utils/cache.py
+++ b/src/tradingview_mcp/core/utils/cache.py
@@ -1,0 +1,195 @@
+"""Generic TTL cache + ``@cached`` decorator for read-only services.
+
+Extracted from ``screener_provider.py`` so the same primitives can be reused
+across services that hit external HTTP APIs (Yahoo, RSS feeds, Reddit, Yahoo
+Options). All caches are in-memory, thread-safe, and TTL-tunable via env
+vars at call time (so tests can monkeypatch env without instance churn).
+
+Design:
+
+- ``TTLCache`` is TTL-agnostic — the caller supplies the freshness window on
+  every ``.get()`` call. This makes it cheap to read env vars at call time
+  and lets one instance serve multiple semantics (fresh window + stale
+  window, as ``screener_provider`` uses for stale-while-error).
+- ``MISS`` sentinel distinguishes a cache miss from a cached ``None`` value.
+- ``@cached`` decorator wraps a function so a key is computed via ``key_fn``,
+  fresh TTL is read from ``ttl_env``, and an optional ``cache_unless``
+  predicate suppresses caching of error responses.
+"""
+from __future__ import annotations
+
+import functools
+import os
+import time
+from threading import RLock
+from typing import Any, Callable, Dict, Hashable, Optional, Tuple
+
+
+__all__ = ["TTLCache", "MISS", "cached", "env_ttl"]
+
+
+class _Miss:
+    """Singleton sentinel used to distinguish miss from a cached ``None``."""
+
+    _instance: Optional["_Miss"] = None
+
+    def __new__(cls) -> "_Miss":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return "<cache.MISS>"
+
+    def __bool__(self) -> bool:  # pragma: no cover - cosmetic
+        return False
+
+
+MISS: _Miss = _Miss()
+
+
+class TTLCache:
+    """Thread-safe key→payload cache with caller-supplied TTLs.
+
+    The instance does not store its own TTL — every read passes the TTL it
+    cares about. This lets the same store serve both a short fresh window
+    and a long stale-while-error window from one set of entries.
+    """
+
+    def __init__(self) -> None:
+        self._store: Dict[Hashable, Tuple[float, Any]] = {}
+        self._lock = RLock()
+        self.hits = 0
+        self.misses = 0
+
+    # -- core ops -----------------------------------------------------------
+
+    def get(self, key: Hashable, ttl_s: float) -> Any:
+        """Return cached payload if its age ≤ ``ttl_s``, else ``MISS``.
+
+        ``ttl_s`` ≤ 0 disables the cache (always returns ``MISS``) but does
+        NOT evict the entry — a subsequent ``get_with_age`` call can still
+        retrieve it within a longer window.
+        """
+        if ttl_s <= 0:
+            return MISS
+        with self._lock:
+            entry = self._store.get(key)
+            if not entry:
+                self.misses += 1
+                return MISS
+            ts, payload = entry
+            if time.time() - ts > ttl_s:
+                self.misses += 1
+                return MISS
+            self.hits += 1
+            return payload
+
+    def get_with_age(
+        self, key: Hashable, max_age_s: float
+    ) -> Optional[Tuple[float, Any]]:
+        """Return ``(age_seconds, payload)`` if entry exists within ``max_age_s``.
+
+        Used for stale-while-error fallback. Returns ``None`` if no entry or
+        the entry exceeds ``max_age_s`` — in which case the stale entry is
+        also evicted so the cache doesn't grow unbounded on dead keys.
+        """
+        if max_age_s <= 0:
+            return None
+        with self._lock:
+            entry = self._store.get(key)
+            if not entry:
+                return None
+            ts, payload = entry
+            age = time.time() - ts
+            if age > max_age_s:
+                self._store.pop(key, None)
+                return None
+            return (age, payload)
+
+    def set(self, key: Hashable, payload: Any) -> None:
+        with self._lock:
+            self._store[key] = (time.time(), payload)
+
+    def invalidate(self, key: Hashable) -> None:
+        with self._lock:
+            self._store.pop(key, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+            self.hits = 0
+            self.misses = 0
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+
+# ---------------------------------------------------------------------------
+# Env helpers + decorator
+# ---------------------------------------------------------------------------
+
+
+def env_ttl(env_var: str, default_s: float) -> float:
+    """Read a non-negative TTL (seconds) from environment, with a default.
+
+    Re-read on every call so monkeypatched env in tests applies immediately.
+    """
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default_s
+    try:
+        v = float(raw)
+    except ValueError:
+        return default_s
+    return v if v >= 0 else default_s
+
+
+def cached(
+    *,
+    key_fn: Callable[..., Hashable],
+    ttl_env: str,
+    default_ttl: float,
+    cache_unless: Optional[Callable[[Any], bool]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorate ``fn`` so its result is cached by ``key_fn(*args, **kwargs)``.
+
+    Args:
+        key_fn: Builds a hashable cache key from the call's args. Returned
+            value is wrapped under the function's qualname so different
+            decorated callables can never collide.
+        ttl_env: Env var name read on every call. Setting it to ``0``
+            disables caching at runtime.
+        default_ttl: Fallback TTL in seconds when env var is unset/invalid.
+        cache_unless: Optional predicate ``(result) -> bool``. If it returns
+            True for a result, the result is returned to the caller but
+            NOT stored — used to skip caching error responses like
+            ``{"error": "..."}``.
+
+    Wrapped function gains two attributes:
+        - ``cache_clear()``: drop all entries
+        - ``cache``: the underlying ``TTLCache`` for inspection/tests
+    """
+    cache = TTLCache()
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        namespace = getattr(fn, "__qualname__", fn.__name__)
+
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            ttl = env_ttl(ttl_env, default_ttl)
+            key = (namespace, key_fn(*args, **kwargs))
+            hit = cache.get(key, ttl)
+            if hit is not MISS:
+                return hit
+            result = fn(*args, **kwargs)
+            if cache_unless is None or not cache_unless(result):
+                cache.set(key, result)
+            return result
+
+        wrapper.cache_clear = cache.clear  # type: ignore[attr-defined]
+        wrapper.cache = cache  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/tests/unit/services/test_screener_provider_resilience.py
+++ b/tests/unit/services/test_screener_provider_resilience.py
@@ -72,7 +72,7 @@ def test_retry_then_succeed(fast_retry):
     calls = {"n": 0}
 
     class FakeQuery:
-        def get_scanner_data(self, cookies=None):
+        def get_scanner_data(self, cookies=None, proxies=None):
             calls["n"] += 1
             if calls["n"] < 3:
                 raise _empty_body_error()
@@ -86,7 +86,7 @@ def test_retry_then_succeed(fast_retry):
 def test_persistent_failure_raises_runtime_error(fast_retry):
     """All retries fail and no cache → RuntimeError with actionable message."""
     class FakeQuery:
-        def get_scanner_data(self, cookies=None):
+        def get_scanner_data(self, cookies=None, proxies=None):
             raise _empty_body_error()
 
     with pytest.raises(RuntimeError) as exc_info:
@@ -110,7 +110,7 @@ def test_stale_while_error_returns_cached_payload(fast_retry):
         sp._SCREENER_CACHE[cache_key] = (ts - 120.0, payload)  # 2 min old
 
     class FakeQuery:
-        def get_scanner_data(self, cookies=None):
+        def get_scanner_data(self, cookies=None, proxies=None):
             raise _empty_body_error()
 
     total, df = sp._scan_with_retry(FakeQuery(), cache_key=cache_key)
@@ -120,7 +120,7 @@ def test_stale_while_error_returns_cached_payload(fast_retry):
 def test_non_transient_error_propagates_immediately(fast_retry):
     """Non-transient errors must NOT be silenced by the retry layer."""
     class FakeQuery:
-        def get_scanner_data(self, cookies=None):
+        def get_scanner_data(self, cookies=None, proxies=None):
             raise ValueError("schema mismatch")
 
     with pytest.raises(ValueError):

--- a/tests/unit/services/test_screener_provider_resilience.py
+++ b/tests/unit/services/test_screener_provider_resilience.py
@@ -20,11 +20,19 @@ from tradingview_mcp.core.services import screener_provider as sp
 @pytest.fixture(autouse=True)
 def _reset_state():
     """Clear cache + last-failure timestamp between tests."""
-    with sp._SCREENER_CACHE_LOCK:
-        sp._SCREENER_CACHE.clear()
+    sp._SCREENER_CACHE.clear()
     with sp._TA_FAILURE_LOCK:
         sp._LAST_TA_FAILURE_TS = 0.0
     yield
+
+
+def _backdate_cache_entry(cache_key, seconds: float) -> None:
+    """Shift an entry's stored timestamp into the past so the fresh window
+    misses but the stale window still hits."""
+    cache = sp._SCREENER_CACHE
+    with cache._lock:
+        ts, payload = cache._store[cache_key]
+        cache._store[cache_key] = (ts - seconds, payload)
 
 
 @pytest.fixture
@@ -105,9 +113,7 @@ def test_stale_while_error_returns_cached_payload(fast_retry):
 
     # Force the freshness window to be already expired so _cache_get misses,
     # but stale lookup still hits.
-    with sp._SCREENER_CACHE_LOCK:
-        ts, payload = sp._SCREENER_CACHE[cache_key]
-        sp._SCREENER_CACHE[cache_key] = (ts - 120.0, payload)  # 2 min old
+    _backdate_cache_entry(cache_key, 120.0)  # 2 min old
 
     class FakeQuery:
         def get_scanner_data(self, cookies=None, proxies=None):
@@ -195,9 +201,7 @@ def test_resilient_ta_returns_stale_on_persistent_failure(fast_retry, monkeypatc
     # Manually expire the FRESH window so the next call must re-fetch,
     # but stale window still holds.
     cache_key = ("ta_multi_v1", "egypt", "1D", ("EGX:ASCM",))
-    with sp._SCREENER_CACHE_LOCK:
-        ts, payload = sp._SCREENER_CACHE[cache_key]
-        sp._SCREENER_CACHE[cache_key] = (ts - 120.0, payload)
+    _backdate_cache_entry(cache_key, 120.0)
 
     # Upstream now broken; stale fallback should kick in
     result = sp.resilient_get_multiple_analysis("egypt", "1D", ["EGX:ASCM"])

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -1,0 +1,396 @@
+"""Unit tests for ``core/utils/cache.py``.
+
+Covers TTLCache primitives (get/set/get_with_age/clear), the ``@cached``
+decorator (key derivation, env-tunable TTL, error suppression via
+``cache_unless``), and basic thread-safety.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from tradingview_mcp.core.utils.cache import MISS, TTLCache, cached, env_ttl
+
+
+# ---------------------------------------------------------------------------
+# TTLCache primitives
+# ---------------------------------------------------------------------------
+
+
+def test_ttlcache_returns_miss_for_unknown_key():
+    cache = TTLCache()
+    assert cache.get("missing", ttl_s=10.0) is MISS
+
+
+def test_ttlcache_hit_within_ttl():
+    cache = TTLCache()
+    cache.set("k", {"v": 1})
+    assert cache.get("k", ttl_s=10.0) == {"v": 1}
+
+
+def test_ttlcache_can_cache_none_value():
+    """MISS sentinel lets us distinguish miss from a cached None payload."""
+    cache = TTLCache()
+    cache.set("k", None)
+    # Cached value is None — but it's a real hit, not a miss.
+    assert cache.get("k", ttl_s=10.0) is None
+    assert cache.get("absent", ttl_s=10.0) is MISS
+
+
+def test_ttlcache_expiry():
+    cache = TTLCache()
+    cache.set("k", "payload")
+    # Stuff the timestamp backward so the entry is now "old".
+    with cache._lock:
+        ts, payload = cache._store["k"]
+        cache._store["k"] = (ts - 100.0, payload)
+    assert cache.get("k", ttl_s=10.0) is MISS
+
+
+def test_ttlcache_zero_ttl_disables_get():
+    cache = TTLCache()
+    cache.set("k", "v")
+    assert cache.get("k", ttl_s=0.0) is MISS
+    # But entry remains for get_with_age:
+    out = cache.get_with_age("k", max_age_s=10.0)
+    assert out is not None
+    assert out[1] == "v"
+
+
+def test_ttlcache_get_with_age_returns_age_and_payload():
+    cache = TTLCache()
+    cache.set("k", "stale")
+    with cache._lock:
+        ts, payload = cache._store["k"]
+        cache._store["k"] = (ts - 60.0, payload)
+    out = cache.get_with_age("k", max_age_s=300.0)
+    assert out is not None
+    age, value = out
+    assert value == "stale"
+    assert 50.0 <= age <= 70.0  # ~60s old, with slack for test runtime
+
+
+def test_ttlcache_get_with_age_evicts_too_old_entries():
+    cache = TTLCache()
+    cache.set("k", "ancient")
+    with cache._lock:
+        ts, payload = cache._store["k"]
+        cache._store["k"] = (ts - 1000.0, payload)
+    assert cache.get_with_age("k", max_age_s=300.0) is None
+    # Entry should be evicted so cache doesn't grow unbounded on dead keys.
+    assert "k" not in cache._store
+
+
+def test_ttlcache_invalidate_drops_single_key():
+    cache = TTLCache()
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.invalidate("a")
+    assert cache.get("a", ttl_s=10.0) is MISS
+    assert cache.get("b", ttl_s=10.0) == 2
+
+
+def test_ttlcache_clear_resets_state():
+    cache = TTLCache()
+    cache.set("a", 1)
+    cache.get("a", ttl_s=10.0)
+    cache.get("missing", ttl_s=10.0)
+    assert cache.hits == 1
+    assert cache.misses == 1
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.hits == 0
+    assert cache.misses == 0
+
+
+def test_ttlcache_hits_and_misses_counted():
+    cache = TTLCache()
+    cache.set("k", 1)
+    cache.get("k", ttl_s=10.0)
+    cache.get("k", ttl_s=10.0)
+    cache.get("absent", ttl_s=10.0)
+    assert cache.hits == 2
+    assert cache.misses == 1
+
+
+# ---------------------------------------------------------------------------
+# env_ttl
+# ---------------------------------------------------------------------------
+
+
+def test_env_ttl_default_when_unset(monkeypatch):
+    monkeypatch.delenv("MY_TTL", raising=False)
+    assert env_ttl("MY_TTL", 42.0) == 42.0
+
+
+def test_env_ttl_reads_int_string(monkeypatch):
+    monkeypatch.setenv("MY_TTL", "120")
+    assert env_ttl("MY_TTL", 42.0) == 120.0
+
+
+def test_env_ttl_reads_float_string(monkeypatch):
+    monkeypatch.setenv("MY_TTL", "0.5")
+    assert env_ttl("MY_TTL", 42.0) == 0.5
+
+
+def test_env_ttl_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("MY_TTL", "not-a-number")
+    assert env_ttl("MY_TTL", 42.0) == 42.0
+
+
+def test_env_ttl_clamps_negative_to_default(monkeypatch):
+    monkeypatch.setenv("MY_TTL", "-5")
+    assert env_ttl("MY_TTL", 42.0) == 42.0
+
+
+# ---------------------------------------------------------------------------
+# @cached decorator
+# ---------------------------------------------------------------------------
+
+
+def test_cached_returns_same_result_within_ttl(monkeypatch):
+    monkeypatch.setenv("TEST_TTL", "60")
+    calls = {"n": 0}
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def expensive(x: int) -> int:
+        calls["n"] += 1
+        return x * 2
+
+    assert expensive(5) == 10
+    assert expensive(5) == 10
+    assert expensive(5) == 10
+    assert calls["n"] == 1
+
+
+def test_cached_different_keys_call_independently(monkeypatch):
+    monkeypatch.setenv("TEST_TTL", "60")
+    calls = {"n": 0}
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def f(x: int) -> int:
+        calls["n"] += 1
+        return x
+
+    f(1); f(2); f(3); f(1); f(2)
+    assert calls["n"] == 3
+
+
+def test_cached_env_zero_disables_cache(monkeypatch):
+    monkeypatch.setenv("TEST_TTL", "0")
+    calls = {"n": 0}
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def f(x: int) -> int:
+        calls["n"] += 1
+        return x
+
+    f(1); f(1); f(1)
+    assert calls["n"] == 3
+
+
+def test_cached_env_change_takes_effect_at_runtime(monkeypatch):
+    """Re-reading env per call is the contract — monkeypatch flips behavior."""
+    calls = {"n": 0}
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=60.0)
+    def f(x: int) -> int:
+        calls["n"] += 1
+        return x
+
+    monkeypatch.setenv("TEST_TTL", "60")
+    f(1); f(1)
+    assert calls["n"] == 1
+
+    # Disable cache at runtime
+    monkeypatch.setenv("TEST_TTL", "0")
+    f(1); f(1)
+    assert calls["n"] == 3
+
+
+def test_cached_uses_default_when_env_missing(monkeypatch):
+    monkeypatch.delenv("TEST_TTL", raising=False)
+    calls = {"n": 0}
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=60.0)
+    def f(x: int) -> int:
+        calls["n"] += 1
+        return x
+
+    f(1); f(1)
+    assert calls["n"] == 1
+
+
+def test_cached_unless_skips_caching_errors(monkeypatch):
+    """cache_unless predicate suppresses storage but still returns the result."""
+    monkeypatch.setenv("TEST_TTL", "60")
+    calls = {"n": 0}
+
+    @cached(
+        key_fn=lambda x: x,
+        ttl_env="TEST_TTL",
+        default_ttl=30.0,
+        cache_unless=lambda r: isinstance(r, dict) and "error" in r,
+    )
+    def maybe_err(x: int) -> dict:
+        calls["n"] += 1
+        if x < 0:
+            return {"error": "bad input"}
+        return {"value": x}
+
+    # Successful calls cache normally
+    assert maybe_err(5) == {"value": 5}
+    assert maybe_err(5) == {"value": 5}
+    assert calls["n"] == 1
+
+    # Error responses are returned but NOT cached
+    assert maybe_err(-1) == {"error": "bad input"}
+    assert maybe_err(-1) == {"error": "bad input"}
+    assert calls["n"] == 3  # both -1 calls hit the underlying fn
+
+
+def test_cached_isolated_per_decorated_function(monkeypatch):
+    """Two decorated callables must not share a cache instance even when
+    using identical key_fn and ttl_env."""
+    monkeypatch.setenv("TEST_TTL", "60")
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def f1(x: int) -> str:
+        return f"f1:{x}"
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def f2(x: int) -> str:
+        return f"f2:{x}"
+
+    assert f1(1) == "f1:1"
+    assert f2(1) == "f2:1"
+
+
+def test_cached_exposes_cache_clear(monkeypatch):
+    monkeypatch.setenv("TEST_TTL", "60")
+    calls = {"n": 0}
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def f(x: int) -> int:
+        calls["n"] += 1
+        return x
+
+    f(1); f(1)
+    assert calls["n"] == 1
+    f.cache_clear()
+    f(1)
+    assert calls["n"] == 2
+
+
+def test_cached_preserves_function_metadata():
+    """functools.wraps must propagate name and docstring."""
+
+    @cached(key_fn=lambda x: x, ttl_env="TEST_TTL", default_ttl=30.0)
+    def my_function(x):
+        """Docstring lives here."""
+        return x
+
+    assert my_function.__name__ == "my_function"
+    assert "Docstring lives here." in (my_function.__doc__ or "")
+
+
+def test_cached_uses_kwargs_in_key(monkeypatch):
+    monkeypatch.setenv("TEST_TTL", "60")
+    calls = {"n": 0}
+
+    @cached(
+        key_fn=lambda symbol, expiry=None: (symbol.upper(), expiry or ""),
+        ttl_env="TEST_TTL",
+        default_ttl=30.0,
+    )
+    def f(symbol, expiry=None):
+        calls["n"] += 1
+        return (symbol, expiry)
+
+    f("aapl")
+    f("AAPL")  # same key after upper
+    f("aapl", expiry="2026-06-21")
+    f("aapl", expiry="2026-06-21")
+    assert calls["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+
+def test_ttlcache_concurrent_set_and_get():
+    cache = TTLCache()
+    n_threads = 20
+    n_ops = 200
+    errors = []
+
+    def worker(thread_id: int):
+        try:
+            for i in range(n_ops):
+                key = (thread_id, i % 10)
+                cache.set(key, thread_id * 1000 + i)
+                got = cache.get(key, ttl_s=60.0)
+                # got may be a later set from same thread; just ensure non-MISS
+                assert got is not MISS
+        except AssertionError as e:  # pragma: no cover - failure path
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=worker, args=(t,)) for t in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"thread errors: {errors}"
+
+
+def test_cached_decorator_thread_safe():
+    """Concurrent callers must all get the right result without exceptions,
+    and a follow-up wave after the first batch settles must be served from
+    cache. We don't single-flight concurrent misses — that would be
+    over-engineering for read-only data — so the first wave may all miss.
+    """
+
+    call_count = {"n": 0}
+    count_lock = threading.Lock()
+
+    @cached(
+        key_fn=lambda x: x,
+        ttl_env="NEVER_SET_THIS_VAR",
+        default_ttl=60.0,
+    )
+    def slow_fn(x: int) -> int:
+        with count_lock:
+            call_count["n"] += 1
+        time.sleep(0.005)
+        return x * 2
+
+    # First wave: concurrent misses are allowed to race past .get()
+    results: list[int] = []
+    res_lock = threading.Lock()
+
+    def worker():
+        out = slow_fn(7)
+        with res_lock:
+            results.append(out)
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 20
+    assert all(r == 14 for r in results)
+
+    # After the first wave settles, the entry is cached. A second wave must
+    # NOT trigger any additional fn calls.
+    before = call_count["n"]
+    for _ in range(20):
+        assert slow_fn(7) == 14
+    assert call_count["n"] == before


### PR DESCRIPTION
## Summary

- Extracts `_cache_get`/`_cache_set` from `screener_provider.py` into a reusable `core/utils/cache.py` providing a thread-safe `TTLCache` (with optional stale-while-error `get_with_age`) and a `@cached(key_fn, ttl_env, default_ttl, cache_unless=...)` decorator.
- Wraps the 5 read-only services that previously re-issued an HTTP call on every invocation. A skill that asks `yahoo_price(AMZN)` five times now makes one HTTP call. Per-tool TTLs are env-tunable so operators can tighten or loosen freshness without code changes.
- `screener_provider` keeps its existing `TRADINGVIEW_MCP_CACHE_TTL` semantics (env re-read on every access) — it now delegates to the shared `TTLCache` instead of carrying its own dict + lock.

## Services wrapped

| Tool | Env var | Default TTL |
| --- | --- | --- |
| `yahoo_finance.get_price` | `CACHE_TTL_YAHOO_PRICE` | 30 s |
| `extended_hours.get_extended_hours_price` | `CACHE_TTL_EXTENDED_HOURS` | 30 s |
| `news.fetch_news` | `CACHE_TTL_NEWS` | 300 s |
| `sentiment.analyze_sentiment` | `CACHE_TTL_SENTIMENT` | 300 s |
| `options.get_options_chain` | `CACHE_TTL_OPTIONS_CHAIN` | 60 s |
| `options.get_unusual_options_activity` | `CACHE_TTL_OPTIONS_UNUSUAL` | 60 s |

Set any env to `0` to disable that tool's cache at runtime.

## Design choices

- **Caller-supplied TTL on every `.get()`** — the cache doesn't store its own TTL so env-var changes take effect immediately and the same instance can serve both fresh + stale windows (used by `screener_provider`'s stale-while-error pattern).
- **`MISS` sentinel** distinguishes a real miss from a cached `None`.
- **`cache_unless` predicate** skips caching of error envelopes (e.g. `{"error": "..."}`) so transient HTTP failures aren't memoized for the TTL window — users retry and get a fresh attempt.
- **Per-decorated-function cache instance** — each `@cached` call gets its own `TTLCache` so two services can never collide.

## Tests

- 27 new unit tests in `tests/unit/utils/test_cache.py` covering: TTL expiry, `get_with_age` stale fallback + eviction, `MISS` vs cached `None`, env override at runtime, `cache_unless` skipping errors, decorator metadata preservation, isolation between decorated functions, and basic thread safety.
- Full suite: **148 passed** (121 pre-existing + 27 new).

## Test plan

- [x] `pytest tests/` — 148 passed in 0.18 s
- [x] All wrapped services importable; each `.cache` attribute is a distinct `TTLCache` instance
- [x] Rebased onto current upstream `main` (`dba8512`); conflicts in `.gitignore` and `screener_provider.py` resolved cleanly (PR #37's new `fetch_atr_for_tickers` does its own HTTP without the cache primitives, no behavioral overlap)

## Backwards compatibility

No public API changes. All wrapped functions keep their signatures, return shapes, and error contracts. `screener_provider`'s `TRADINGVIEW_MCP_CACHE_TTL` env var still works exactly as before.