### PR TITLE
fix: BB rating signal returns NEUTRAL for extreme readings (±3)

### DIFF
--- a/src/tradingview_mcp/core/services/indicators.py
+++ b/src/tradingview_mcp/core/services/indicators.py
@@ -31,9 +31,9 @@ def compute_bb_rating_signal(close: float, bb_upper: float, bb_middle: float, bb
         rating = -1
 
     signal = "NEUTRAL"
-    if rating == 2:
+    if rating >= 2:
         signal = "BUY"
-    elif rating == -2:
+    elif rating <= -2:
         signal = "SELL"
     return rating, signal
 


### PR DESCRIPTION
## Problem

`compute_bb_rating_signal()` maps price position relative to Bollinger Bands into a -3/+3 integer rating:

| Condition | Rating |
|---|---|
| close > upper band | +3 |
| close > middle + 50% of upper half | +2 |
| close > middle | +1 |
| close < lower band | -3 |
| close < middle - 50% of lower half | -2 |
| close < middle | -1 |

The downstream signal string mapping uses strict equality:

```python
signal = "NEUTRAL"
if rating == 2:
    signal = "BUY"
elif rating == -2:
    signal = "SELL"
```

Rating ±3 — the most extreme readings — fall through to `NEUTRAL`. A price breaking above the upper band (bullish breakout) or crashing below the lower band (bearish breakdown) is reported as neutral. This propagates through `coin_analysis`, `rating_filter`, `top_gainers`, and any consumer of `compute_metrics`.

## Fix

```python
if rating >= 2:
    signal = "BUY"
elif rating <= -2:
    signal = "SELL"
```

Two-character change. No new dependencies, no API surface change.

## Testing

Verified locally against KUCOIN BTCUSDT 4h — coins with rating=3 now correctly return signal=BUY instead of NEUTRAL.