### PR TITLE
fix: correct OBV direction calculation to use candle range position

### DIFF
--- a/src/tradingview_mcp/core/services/indicators.py
+++ b/src/tradingview_mcp/core/services/indicators.py
@@ -104,13 +104,24 @@ def extract_extended_indicators(indicators: Dict) -> Dict:
 
     # --- OBV (On Balance Volume) ---
     obv_direction = None
-    if volume is not None and open_price and close:
-        obv_direction = "accumulation" if close > open_price else "distribution" if close < open_price else "neutral"
+    if volume is not None and open_price and close and high and low:
+        candle_range = high - low
+        if candle_range > 0:
+            # Close position within the candle range (0 = at low, 1 = at high)
+            close_position = (close - low) / candle_range
+            if close_position >= 0.7:
+                obv_direction = "accumulation"
+            elif close_position <= 0.3:
+                obv_direction = "distribution"
+            else:
+                obv_direction = "neutral"
+        else:
+            obv_direction = "neutral"
 
     obv = {
         "current_volume": _safe_round(volume, 0),
         "direction": obv_direction,
-        "note": "OBV direction inferred from current candle (close vs open)",
+        "note": "OBV direction inferred from close position within candle range (0-30%: distribution, 70-100%: accumulation)",
     }
 
     # --- SMA (Simple Moving Average) ---


### PR DESCRIPTION
## Bug
OBV direction was calculated as `close > open_price` — just checking if a candle is green/red. This is not OBV, it's candle color detection.

**Examples of wrong behavior:**
- Long lower wick candle (buyers defended) → could still show "distribution" if close < open
- Long upper wick candle (sellers rejected) → could still show "accumulation" if close > open

## Fix
Calculate where the close sits within the candle's **high-low range**:
- `close_position = (close - low) / (high - low)`
- **≥ 70%**: accumulation (buyers dominated the range)
- **≤ 30%**: distribution (sellers dominated the range)
- **30-70%**: neutral (contested)

This properly captures:
- ✅ Lower wick buying pressure → accumulation
- ✅ Upper wick selling pressure → distribution
- ✅ Doji / no movement → neutral
- ✅ Missing high/low data → graceful fallback

## Testing
