### PR TITLE
fix(screener): bound HTTP timeouts + stale-while-error fallback to kill MCP hangs

### DIFF
--- a/src/tradingview_mcp/core/services/egx_service.py
+++ b/src/tradingview_mcp/core/services/egx_service.py
@@ -24,6 +24,9 @@ from tradingview_mcp.core.services.indicators import (
 )
 from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, sanitize_timeframe
 
+# Resilience layer (no tradingview_ta dependency; safe to import unconditionally).
+from tradingview_mcp.core.services.screener_provider import _scan_with_retry
+
 try:
     # Patched: route through resilience layer (retry + 60s TTL cache).
     import tradingview_ta  # noqa: F401  presence check
@@ -1039,7 +1042,11 @@ def analyze_egx_fibonacci(
                 .select("close", high_col, low_col)
                 .set_tickers([full_symbol])
             )
-            _, df = q.get_scanner_data()
+            # Route through resilience layer (retry + stale-while-error).
+            # Cache key scoped to egx_fib_swing so it doesn't collide with
+            # other screener queries on the same ticker.
+            fib_cache_key = ("egx_fib_swing_v1", full_symbol, lookback)
+            _, df = _scan_with_retry(q, cache_key=fib_cache_key)
             if not df.empty:
                 row = df.iloc[0]
                 h = row.get(high_col)

--- a/src/tradingview_mcp/core/services/screener_provider.py
+++ b/src/tradingview_mcp/core/services/screener_provider.py
@@ -3,21 +3,88 @@ from typing import List, Dict, Any, Optional, Tuple
 from ..utils.validators import get_market_type
 import json as _json
 import os as _os
+import random as _random
+import socket as _socket
 import sys as _sys
 import time as _time
 from threading import RLock as _RLock, Semaphore as _Semaphore, Lock as _Lock
 
 
-# --- Resilience layer (added 2026-05-13) -----------------------------------
+# --- Socket-level timeout (added 2026-05-20) ------------------------------
+# Critical: tradingview_ta and tradingview-screener use urllib without an
+# explicit timeout, so when scanner.tradingview.com opens a connection then
+# stops sending bytes, calls hang INDEFINITELY. The retry layer can't fire
+# because no exception is ever raised. Set socket default timeout so any
+# stalled HTTP call fails with socket.timeout within a bounded window — the
+# retry layer then catches it (TimeoutError is now treated as transient).
+#
+# Tunable: TRADINGVIEW_MCP_SOCKET_TIMEOUT (default 20 seconds).
+def _socket_timeout_s() -> float:
+    try:
+        return max(1.0, float(_os.environ.get('TRADINGVIEW_MCP_SOCKET_TIMEOUT', '20')))
+    except Exception:
+        return 20.0
+
+
+_SOCKET_TIMEOUT_APPLIED = False
+
+
+def _ensure_socket_timeout() -> None:
+    """Apply socket.setdefaulttimeout once per process. Idempotent."""
+    global _SOCKET_TIMEOUT_APPLIED
+    if _SOCKET_TIMEOUT_APPLIED:
+        return
+    t = _socket_timeout_s()
+    try:
+        _socket.setdefaulttimeout(t)
+        _SOCKET_TIMEOUT_APPLIED = True
+        try:
+            print(
+                f"[tradingview_mcp] socket default timeout set to {t:.1f}s",
+                file=_sys.stderr,
+            )
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+
+# Apply at module import time so all TV HTTP calls inherit the timeout.
+_ensure_socket_timeout()
+
+
+# --- Resilience layer (added 2026-05-13, hardened 2026-05-20) --------------
 # TradingView's scanner.tradingview.com endpoint occasionally returns an empty
 # body on transient hiccups, causing tradingview-screener to raise
 # json.JSONDecodeError("Expecting value: line 1 column 1 (char 0)").
-# We retry with exponential backoff and cache successful results briefly to
-# absorb these blips without surfacing them to skill callers.
+# We retry with exponential backoff (+ jitter) and cache successful results
+# (with a stale-while-error fallback) so transient outages don't surface to
+# skill callers.
+#
+# 2026-05-20 hardening:
+# - Added ±20% jitter so parallel callers don't form synchronized retry
+#   storms (the 5-stock parallel batch failure mode).
+# - Added stale-while-error cache: on full retry exhaustion, return the most
+#   recent successful result (up to TRADINGVIEW_MCP_STALE_TTL=6h old).
+#   This is the primary defense against deep outages — for repeat queries
+#   we always serve from cache rather than burn long retries.
+# - Final terminal error now includes attempt count, total wait, and an
+#   explicit "wait N seconds before retry" suggestion (no more bare
+#   JSONDecodeError surfacing to skill callers).
+# - Routed the 3 remaining direct ``q.get_scanner_data()`` callsites
+#   (egx_fibonacci, screener_service.multi_changes, screener_service.scan)
+#   through ``_scan_with_retry`` so they share the resilience layer.
+#
+# Retry budget design: kept moderate (~52s) so interactive tools fail
+# clearly rather than feeling "stuck". For sustained outages we rely on
+# the 6h stale cache to serve previously-seen symbols.
 #
 # Tunables (env vars):
-#   TRADINGVIEW_MCP_CACHE_TTL   default 60 (seconds). Set 0 to disable cache.
-#   TRADINGVIEW_MCP_RETRY_DELAYS default "0.5,1.5,4.0" (sec, comma-separated)
+#   TRADINGVIEW_MCP_CACHE_TTL    default 60   (seconds — fresh cache)
+#   TRADINGVIEW_MCP_STALE_TTL    default 21600 (6 hours — fallback cache)
+#   TRADINGVIEW_MCP_RETRY_DELAYS default "2.0,5.0,15.0,30.0"
+#   TRADINGVIEW_MCP_RETRY_JITTER default 0.2  (±20% jitter on each delay)
+#   TRADINGVIEW_MCP_FAILURE_COOLDOWN_S default 60 (seconds)
 
 def _cache_ttl_s() -> float:
     try:
@@ -26,19 +93,95 @@ def _cache_ttl_s() -> float:
         return 60.0
 
 
+def _stale_ttl_s() -> float:
+    try:
+        return max(0.0, float(_os.environ.get('TRADINGVIEW_MCP_STALE_TTL', '21600')))
+    except Exception:
+        return 21600.0
+
+
 def _retry_delays() -> tuple:
-    raw = _os.environ.get('TRADINGVIEW_MCP_RETRY_DELAYS', '0.5,1.5,4.0')
+    # Tighter default 2026-05-20 hardening: with socket timeout now bounding
+    # each attempt to ~20s, we only need 2-3 retries before stale fallback
+    # or terminal error. Previous 4-retry budget made interactive callers
+    # feel "stuck" when upstream was truly dead.
+    raw = _os.environ.get('TRADINGVIEW_MCP_RETRY_DELAYS', '1.0,4.0')
     try:
         return tuple(float(x) for x in raw.split(',') if x.strip())
     except Exception:
-        return (0.5, 1.5, 4.0)
+        return (1.0, 4.0)
 
 
-_SCREENER_CACHE: Dict[Tuple, Tuple[float, Tuple[int, Any]]] = {}
+def _retry_jitter() -> float:
+    try:
+        return max(0.0, min(1.0, float(_os.environ.get('TRADINGVIEW_MCP_RETRY_JITTER', '0.2'))))
+    except Exception:
+        return 0.2
+
+
+def _jittered(delay: float) -> float:
+    """Apply ±jitter to a delay so parallel callers don't synchronize retries."""
+    j = _retry_jitter()
+    if j <= 0 or delay <= 0:
+        return delay
+    return max(0.0, delay * (1.0 + _random.uniform(-j, j)))
+
+
+# --- Shared failure cooldown (added 2026-05-19) ---------------------------
+# When a call exhausts all retries (sustained upstream outage), the next
+# call shouldn't immediately re-hammer with another full retry round —
+# that just compounds load on a struggling upstream. After a full-retry
+# failure, subsequent calls wait up to TRADINGVIEW_MCP_FAILURE_COOLDOWN_S
+# seconds before starting their own retry sequence, giving upstream room
+# to recover. The cooldown decays as time passes since last failure.
+def _failure_cooldown_s() -> float:
+    # Tightened 2026-05-20: 15s is enough to absorb a brief upstream blip
+    # without compounding wait time across multiple skill calls.
+    try:
+        return max(0.0, float(_os.environ.get('TRADINGVIEW_MCP_FAILURE_COOLDOWN_S', '15')))
+    except Exception:
+        return 15.0
+
+
+_LAST_TA_FAILURE_TS: float = 0.0
+_TA_FAILURE_LOCK = _Lock()
+
+
+def _record_ta_failure() -> None:
+    global _LAST_TA_FAILURE_TS
+    with _TA_FAILURE_LOCK:
+        _LAST_TA_FAILURE_TS = _time.time()
+
+
+def _wait_for_failure_cooldown() -> None:
+    """If a previous call recently exhausted all retries, sleep until the
+    cooldown elapses before starting a new retry sequence."""
+    cooldown = _failure_cooldown_s()
+    if cooldown <= 0:
+        return
+    with _TA_FAILURE_LOCK:
+        ts = _LAST_TA_FAILURE_TS
+    if ts == 0.0:
+        return
+    elapsed = _time.time() - ts
+    if elapsed < cooldown:
+        wait = cooldown - elapsed
+        try:
+            print(
+                f"[tradingview_mcp] failure cooldown active, sleeping {wait:.1f}s",
+                file=_sys.stderr,
+            )
+        except Exception:
+            pass
+        _time.sleep(wait)
+
+
+_SCREENER_CACHE: Dict[Tuple, Tuple[float, Any]] = {}
 _SCREENER_CACHE_LOCK = _RLock()
 
 
 def _cache_get(key: Tuple):
+    """Return cached payload if fresh (within TRADINGVIEW_MCP_CACHE_TTL)."""
     ttl = _cache_ttl_s()
     if ttl <= 0:
         return None
@@ -48,13 +191,36 @@ def _cache_get(key: Tuple):
             return None
         ts, payload = entry
         if _time.time() - ts > ttl:
-            _SCREENER_CACHE.pop(key, None)
+            # Don't pop here — stale lookup below may still want it.
             return None
         return payload
 
 
-def _cache_set(key: Tuple, payload: Tuple[int, Any]) -> None:
-    if _cache_ttl_s() <= 0:
+def _cache_get_stale(key: Tuple) -> Optional[Tuple[float, Any]]:
+    """Return (age_seconds, payload) if a stale-but-usable entry exists
+    (older than fresh TTL, younger than stale TTL). Used as last-resort
+    fallback when fresh upstream fetch fails persistently."""
+    stale_ttl = _stale_ttl_s()
+    if stale_ttl <= 0:
+        return None
+    with _SCREENER_CACHE_LOCK:
+        entry = _SCREENER_CACHE.get(key)
+        if not entry:
+            return None
+        ts, payload = entry
+        age = _time.time() - ts
+        if age > stale_ttl:
+            _SCREENER_CACHE.pop(key, None)
+            return None
+        return (age, payload)
+
+
+def _cache_set(key: Tuple, payload: Any) -> None:
+    """Store payload. We always store (even if fresh TTL is 0) so the
+    stale-while-error fallback can serve it later within STALE_TTL."""
+    stale_ttl = _stale_ttl_s()
+    fresh_ttl = _cache_ttl_s()
+    if stale_ttl <= 0 and fresh_ttl <= 0:
         return
     with _SCREENER_CACHE_LOCK:
         _SCREENER_CACHE[key] = (_time.time(), payload)
@@ -73,16 +239,19 @@ def _cache_set(key: Tuple, payload: Tuple[int, Any]) -> None:
 
 def _max_inflight() -> int:
     try:
-        return max(1, int(_os.environ.get('TRADINGVIEW_MCP_MAX_INFLIGHT', '4')))
+        return max(1, int(_os.environ.get('TRADINGVIEW_MCP_MAX_INFLIGHT', '2')))
     except Exception:
-        return 4
+        return 2
 
 
 def _min_interval_s() -> float:
+    # Tightened 2026-05-20: now that each call is bounded by socket timeout,
+    # we don't need a 1.5s gate between starts. 0.5s is enough to avoid
+    # synchronized request bursts without serializing parallel batches.
     try:
-        return max(0.0, float(_os.environ.get('TRADINGVIEW_MCP_MIN_INTERVAL_S', '0.8')))
+        return max(0.0, float(_os.environ.get('TRADINGVIEW_MCP_MIN_INTERVAL_S', '0.5')))
     except Exception:
-        return 0.8
+        return 1.5
 
 
 _TA_SEMAPHORE = _Semaphore(_max_inflight())
@@ -114,8 +283,11 @@ def _ta_throttle_release() -> None:
 
 def _is_transient_screener_error(e: BaseException) -> bool:
     """True if the error looks like an upstream transient (empty body,
-    JSON parse failure, connection reset, rate limit message)."""
+    JSON parse failure, connection reset, rate limit, or socket timeout)."""
     if isinstance(e, _json.JSONDecodeError):
+        return True
+    # socket.timeout, urllib's ReadTimeoutError, requests.exceptions.Timeout, etc.
+    if isinstance(e, (TimeoutError, _socket.timeout)):
         return True
     msg = str(e)
     return any(s in msg for s in (
@@ -123,18 +295,40 @@ def _is_transient_screener_error(e: BaseException) -> bool:
         'Connection reset',
         'Connection aborted',
         'Read timed out',
+        'timed out',
         'Temporary failure',
+        'Max retries exceeded',
+        'RemoteDisconnected',
     ))
 
 
-def _scan_with_retry(q, cookies=None):
+def _format_transient_error(last_exc: BaseException, attempts: int, total_wait: float) -> str:
+    """Build an actionable terminal error message for callers."""
+    base = repr(last_exc)
+    return (
+        f"Upstream TradingView scanner returned transient errors on all "
+        f"{attempts} attempts spanning {total_wait:.0f}s ({base}). "
+        f"This is typically a 30-90s empty-body outage at scanner.tradingview.com. "
+        f"Wait ~60s before retrying."
+    )
+
+
+def _scan_with_retry(q, cookies=None, cache_key: Optional[Tuple] = None):
     """Wrap Query.get_scanner_data with retries on transient TV outages.
-    Returns (total, df). Re-raises on non-transient errors or on final failure."""
+    Returns (total, df). Re-raises on non-transient errors or on final failure.
+
+    If ``cache_key`` is provided and all retries fail, attempts to return a
+    stale-but-usable cached payload before raising — callers that pass a key
+    get stale-while-error behavior automatically."""
+    _wait_for_failure_cooldown()
     delays = (0.0,) + _retry_delays()  # immediate try, then back off
     last_exc: Optional[BaseException] = None
+    total_wait = 0.0
     for i, delay in enumerate(delays):
-        if delay > 0:
-            _time.sleep(delay)
+        wait = _jittered(delay) if delay > 0 else 0.0
+        if wait > 0:
+            _time.sleep(wait)
+            total_wait += wait
         try:
             return q.get_scanner_data(cookies=cookies)
         except Exception as e:  # noqa: BLE001 - intentionally broad, narrowed below
@@ -143,23 +337,40 @@ def _scan_with_retry(q, cookies=None):
             last_exc = e
             try:
                 print(
-                    f"[tradingview_mcp] transient scanner error (attempt {i+1}/{len(delays)}): {e!r}",
+                    f"[tradingview_mcp] transient scanner error (attempt {i+1}/{len(delays)}, "
+                    f"slept {wait:.1f}s): {e!r}",
                     file=_sys.stderr,
                 )
             except Exception:
                 pass
             continue
-    # All attempts exhausted
+    # All attempts exhausted — record failure so subsequent calls back off
+    _record_ta_failure()
+    # Last-resort: stale-while-error fallback if we have a cache key
+    if cache_key is not None:
+        stale = _cache_get_stale(cache_key)
+        if stale is not None:
+            age, payload = stale
+            try:
+                print(
+                    f"[tradingview_mcp] returning stale cache (age {age:.0f}s) after "
+                    f"{len(delays)} failed scanner attempts",
+                    file=_sys.stderr,
+                )
+            except Exception:
+                pass
+            return payload
     assert last_exc is not None
-    raise last_exc
+    raise RuntimeError(_format_transient_error(last_exc, len(delays), total_wait)) from last_exc
 
 
 def resilient_get_multiple_analysis(screener, interval, symbols):
     """Drop-in replacement for tradingview_ta.get_multiple_analysis with the
-    same resilience layer used by the screener calls (retry + 60s TTL cache).
-    Required because coin_analysis / combined_analysis / multi_timeframe_analysis
-    use tradingview_ta directly and hit the same transient JSON errors when
-    TradingView's scanner endpoint returns an empty body."""
+    same resilience layer used by the screener calls (retry + cache + stale
+    fallback). Required because coin_analysis / combined_analysis /
+    multi_timeframe_analysis use tradingview_ta directly and hit the same
+    transient JSON errors when TradingView's scanner endpoint returns an
+    empty body."""
     try:
         from tradingview_ta import get_multiple_analysis as _gma  # type: ignore
     except Exception as e:
@@ -171,15 +382,27 @@ def resilient_get_multiple_analysis(screener, interval, symbols):
     if cached is not None:
         return cached
 
+    _wait_for_failure_cooldown()
     delays = (0.0,) + _retry_delays()
     last_exc: Optional[BaseException] = None
+    total_wait = 0.0
     for i, delay in enumerate(delays):
-        if delay > 0:
-            _time.sleep(delay)
+        wait = _jittered(delay) if delay > 0 else 0.0
+        if wait > 0:
+            _time.sleep(wait)
+            total_wait += wait
         try:
             _ta_throttle_acquire()
             try:
-                result = _gma(screener=screener, interval=interval, symbols=symbols)
+                # CRITICAL: tradingview_ta defaults timeout=None, which means
+                # requests.post hangs FOREVER on stalled upstream. socket.setdefaulttimeout
+                # does NOT apply to requests/urllib3. Pass timeout explicitly.
+                result = _gma(
+                    screener=screener,
+                    interval=interval,
+                    symbols=symbols,
+                    timeout=_socket_timeout_s(),
+                )
             finally:
                 _ta_throttle_release()
             _cache_set(cache_key, result)
@@ -190,14 +413,30 @@ def resilient_get_multiple_analysis(screener, interval, symbols):
             last_exc = e
             try:
                 print(
-                    f"[tradingview_mcp] transient TA error (attempt {i+1}/{len(delays)}): {e!r}",
+                    f"[tradingview_mcp] transient TA error (attempt {i+1}/{len(delays)}, "
+                    f"slept {wait:.1f}s): {e!r}",
                     file=_sys.stderr,
                 )
             except Exception:
                 pass
             continue
+    # All attempts exhausted — record failure so subsequent calls back off
+    _record_ta_failure()
+    # Last-resort: stale-while-error fallback (up to TRADINGVIEW_MCP_STALE_TTL)
+    stale = _cache_get_stale(cache_key)
+    if stale is not None:
+        age, payload = stale
+        try:
+            print(
+                f"[tradingview_mcp] returning stale TA cache (age {age:.0f}s, symbols={symbols}) "
+                f"after {len(delays)} failed attempts",
+                file=_sys.stderr,
+            )
+        except Exception:
+            pass
+        return payload
     assert last_exc is not None
-    raise last_exc
+    raise RuntimeError(_format_transient_error(last_exc, len(delays), total_wait)) from last_exc
 
 
 def _tf_to_tv_resolution(tf: Optional[str]) -> Optional[str]:
@@ -376,7 +615,7 @@ def fetch_screener_indicators(
     if _cached is not None:
         total, df = _cached
     else:
-        total, df = _scan_with_retry(q, cookies=cookies)
+        total, df = _scan_with_retry(q, cookies=cookies, cache_key=_cache_key)
         _cache_set(_cache_key, (total, df))
 
     rows: List[Dict[str, Any]] = []
@@ -493,7 +732,7 @@ def fetch_screener_multi_changes(
     if _cached is not None:
         total, df = _cached
     else:
-        total, df = _scan_with_retry(q, cookies=cookies)
+        total, df = _scan_with_retry(q, cookies=cookies, cache_key=_cache_key)
         _cache_set(_cache_key, (total, df))
 
     rows: List[Dict[str, Any]] = []

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -23,6 +23,9 @@ from tradingview_mcp.core.services.coinlist import load_symbols
 from tradingview_mcp.core.services.indicators import compute_metrics
 from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type
 
+# Resilience layer (does not require tradingview_ta; safe to import unconditionally).
+from tradingview_mcp.core.services.screener_provider import _scan_with_retry
+
 try:
     # Patched: route through resilience layer (retry + 60s TTL cache).
     import tradingview_ta  # noqa: F401  presence check
@@ -271,7 +274,15 @@ def fetch_multi_changes(
     if limit:
         q = q.limit(int(limit))
 
-    _total, df = q.get_scanner_data(cookies=cookies)
+    # Route through resilience layer (retry + stale-while-error).
+    mc_cache_key = (
+        "screener_multichanges_v1",
+        (exchange or "").upper(),
+        tuple(sorted(suffix_map.keys())),
+        base_timeframe,
+        int(limit) if limit else None,
+    )
+    _total, df = _scan_with_retry(q, cookies=cookies, cache_key=mc_cache_key)
     if df is None or df.empty:
         return []
 
@@ -412,7 +423,14 @@ def fetch_multi_timeframe_patterns(
         q = q.where(Column("exchange") == exchange.upper())
         q = q.limit(len(symbols))
 
-        _total, df = q.get_scanner_data()
+        # Route through resilience layer (retry + stale-while-error).
+        cp_cache_key = (
+            "screener_candle_pattern_v1",
+            exchange.upper(),
+            tv_interval,
+            tuple(sorted(symbols)),
+        )
+        _total, df = _scan_with_retry(q, cache_key=cp_cache_key)
         if df is None or df.empty:
             return []
 

--- a/tests/unit/services/test_screener_provider_resilience.py
+++ b/tests/unit/services/test_screener_provider_resilience.py
@@ -1,0 +1,204 @@
+"""Unit tests for screener_provider resilience layer.
+
+Locks in 2026-05-20 hardening:
+- Extended retry budget with jitter
+- Stale-while-error cache fallback
+- Actionable terminal error on persistent failure
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from unittest import mock
+
+import pytest
+
+from tradingview_mcp.core.services import screener_provider as sp
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Clear cache + last-failure timestamp between tests."""
+    with sp._SCREENER_CACHE_LOCK:
+        sp._SCREENER_CACHE.clear()
+    with sp._TA_FAILURE_LOCK:
+        sp._LAST_TA_FAILURE_TS = 0.0
+    yield
+
+
+@pytest.fixture
+def fast_retry(monkeypatch):
+    """Shrink retry delays to keep tests fast."""
+    monkeypatch.setenv("TRADINGVIEW_MCP_RETRY_DELAYS", "0.01,0.02,0.03")
+    monkeypatch.setenv("TRADINGVIEW_MCP_RETRY_JITTER", "0")
+    monkeypatch.setenv("TRADINGVIEW_MCP_FAILURE_COOLDOWN_S", "0")
+
+
+def _empty_body_error() -> json.JSONDecodeError:
+    """Same shape the empty-body cliff raises."""
+    return json.JSONDecodeError("Expecting value", "", 0)
+
+
+def test_is_transient_screener_error_catches_empty_body():
+    assert sp._is_transient_screener_error(_empty_body_error()) is True
+    assert sp._is_transient_screener_error(RuntimeError("Connection reset by peer")) is True
+    assert sp._is_transient_screener_error(ValueError("totally unrelated")) is False
+
+
+def test_is_transient_screener_error_catches_socket_timeouts():
+    """Socket timeouts MUST be classified transient so retry layer fires
+    (was causing 8-minute hangs before 2026-05-20 hardening)."""
+    import socket as _socket
+    assert sp._is_transient_screener_error(_socket.timeout()) is True
+    assert sp._is_transient_screener_error(TimeoutError("call timed out")) is True
+    assert sp._is_transient_screener_error(RuntimeError("Read timed out")) is True
+    assert sp._is_transient_screener_error(RuntimeError("Max retries exceeded")) is True
+    assert sp._is_transient_screener_error(RuntimeError("RemoteDisconnected")) is True
+
+
+def test_socket_default_timeout_applied_on_import():
+    """Module import must call socket.setdefaulttimeout() so urllib calls
+    inside tradingview_ta/screener never hang indefinitely."""
+    import socket as _socket
+    t = _socket.getdefaulttimeout()
+    assert t is not None
+    assert t > 0
+    assert t <= 60.0  # sanity: well below the 8-minute hang threshold
+
+
+def test_retry_then_succeed(fast_retry):
+    """Scanner that fails twice then succeeds should return final result."""
+    calls = {"n": 0}
+
+    class FakeQuery:
+        def get_scanner_data(self, cookies=None):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _empty_body_error()
+            return (1, "ok_df")
+
+    total, df = sp._scan_with_retry(FakeQuery())
+    assert (total, df) == (1, "ok_df")
+    assert calls["n"] == 3
+
+
+def test_persistent_failure_raises_runtime_error(fast_retry):
+    """All retries fail and no cache → RuntimeError with actionable message."""
+    class FakeQuery:
+        def get_scanner_data(self, cookies=None):
+            raise _empty_body_error()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        sp._scan_with_retry(FakeQuery())
+
+    msg = str(exc_info.value)
+    assert "transient errors on all" in msg
+    assert "scanner.tradingview.com" in msg
+    assert "Wait" in msg
+
+
+def test_stale_while_error_returns_cached_payload(fast_retry):
+    """When upstream is dead, stale cached data should serve as fallback."""
+    cache_key = ("indicators_v1", "EGX", ("EGX:ASCM",), "1D", None)
+    sp._cache_set(cache_key, (1, "stale_df"))
+
+    # Force the freshness window to be already expired so _cache_get misses,
+    # but stale lookup still hits.
+    with sp._SCREENER_CACHE_LOCK:
+        ts, payload = sp._SCREENER_CACHE[cache_key]
+        sp._SCREENER_CACHE[cache_key] = (ts - 120.0, payload)  # 2 min old
+
+    class FakeQuery:
+        def get_scanner_data(self, cookies=None):
+            raise _empty_body_error()
+
+    total, df = sp._scan_with_retry(FakeQuery(), cache_key=cache_key)
+    assert (total, df) == (1, "stale_df")
+
+
+def test_non_transient_error_propagates_immediately(fast_retry):
+    """Non-transient errors must NOT be silenced by the retry layer."""
+    class FakeQuery:
+        def get_scanner_data(self, cookies=None):
+            raise ValueError("schema mismatch")
+
+    with pytest.raises(ValueError):
+        sp._scan_with_retry(FakeQuery())
+
+
+def test_jitter_within_band(monkeypatch):
+    """_jittered must keep delays within ±jitter of the base value."""
+    monkeypatch.setenv("TRADINGVIEW_MCP_RETRY_JITTER", "0.2")
+    for _ in range(50):
+        d = sp._jittered(10.0)
+        assert 8.0 <= d <= 12.0
+
+
+def test_resilient_ta_uses_fresh_cache_first(fast_retry, monkeypatch):
+    """Fresh cache hit must skip upstream entirely."""
+    call_count = {"n": 0}
+
+    def fake_gma(screener, interval, symbols, **kwargs):
+        call_count["n"] += 1
+        return {"EGX:ASCM": object()}
+
+    fake_module = mock.MagicMock()
+    fake_module.get_multiple_analysis = fake_gma
+    monkeypatch.setitem(__import__("sys").modules, "tradingview_ta", fake_module)
+
+    # First call hits upstream
+    sp.resilient_get_multiple_analysis("egypt", "1D", ["EGX:ASCM"])
+    # Second call within TTL must hit cache
+    sp.resilient_get_multiple_analysis("egypt", "1D", ["EGX:ASCM"])
+    assert call_count["n"] == 1
+
+
+def test_resilient_ta_passes_timeout_explicitly(fast_retry, monkeypatch):
+    """tradingview_ta.get_multiple_analysis defaults timeout=None which would
+    hang requests.post FOREVER on stalled upstream (this was the actual
+    8-minute hang root cause). Resilient wrapper MUST pass timeout=20."""
+    captured = {}
+
+    def fake_gma(screener, interval, symbols, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return {"EGX:ASCM": "ok"}
+
+    fake_module = mock.MagicMock()
+    fake_module.get_multiple_analysis = fake_gma
+    monkeypatch.setitem(__import__("sys").modules, "tradingview_ta", fake_module)
+
+    sp.resilient_get_multiple_analysis("egypt", "1D", ["EGX:ASCM"])
+
+    assert captured["timeout"] is not None, "timeout must be passed explicitly"
+    assert 1.0 <= captured["timeout"] <= 60.0, f"timeout should be a sane value, got {captured['timeout']}"
+
+
+def test_resilient_ta_returns_stale_on_persistent_failure(fast_retry, monkeypatch):
+    """When all retries fail, stale-while-error must serve old result."""
+    call_count = {"n": 0}
+
+    def fake_gma(screener, interval, symbols, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"EGX:ASCM": "good_payload"}
+        raise _empty_body_error()
+
+    fake_module = mock.MagicMock()
+    fake_module.get_multiple_analysis = fake_gma
+    monkeypatch.setitem(__import__("sys").modules, "tradingview_ta", fake_module)
+
+    # Prime the cache with one successful call
+    first = sp.resilient_get_multiple_analysis("egypt", "1D", ["EGX:ASCM"])
+    assert first == {"EGX:ASCM": "good_payload"}
+
+    # Manually expire the FRESH window so the next call must re-fetch,
+    # but stale window still holds.
+    cache_key = ("ta_multi_v1", "egypt", "1D", ("EGX:ASCM",))
+    with sp._SCREENER_CACHE_LOCK:
+        ts, payload = sp._SCREENER_CACHE[cache_key]
+        sp._SCREENER_CACHE[cache_key] = (ts - 120.0, payload)
+
+    # Upstream now broken; stale fallback should kick in
+    result = sp.resilient_get_multiple_analysis("egypt", "1D", ["EGX:ASCM"])
+    assert result == {"EGX:ASCM": "good_payload"}


### PR DESCRIPTION
## Problem

\`tradingview_ta.get_multiple_analysis()\` calls \`requests.post\` with \`timeout=None\`, so when \`scanner.tradingview.com\` opens a TCP connection then stops sending bytes, calls hang **indefinitely**. \`socket.setdefaulttimeout()\` does NOT apply to \`requests\`/\`urllib3\`, so the existing retry layer never sees an exception and never fires. Symptom: parallel \`combined_analysis\` calls on NYSEARCA tickers (SPY/IWM/GLD/GDX) block the MCP server for 8+ minutes until the OS kills the connection.

## Fix — three layered guards

1. **\`socket.setdefaulttimeout(20s)\` at module import** — bounds urllib-based calls (\`tradingview-screener\`) so any stalled HTTP fails with \`socket.timeout\` within a known window. The retry layer then catches it.

2. **Explicit \`timeout=20s\` passed to \`tradingview_ta.get_multiple_analysis\`** — the actual root-cause fix. \`requests\` ignores socket defaults so this had to be wired through.

3. **Stale-while-error fallback** — when all retries exhaust, serve the most recent cached result (up to 6 h old) before raising. Tighter retry budget (\`1s, 4s\` instead of \`0.5s, 1.5s, 4s\`), ±20% jitter to avoid synchronized retry storms across parallel callers, and a 15 s failure cooldown so subsequent calls don't immediately re-hammer.

Plus the 3 remaining direct \`q.get_scanner_data()\` callsites (\`egx_fibonacci\`, \`screener_service.multi_changes\`, \`screener_service.scan\`) now route through \`_scan_with_retry\` so they share the resilience layer.

## New env tunables

| Env var | Default | Purpose |
| --- | --- | --- |
| \`TRADINGVIEW_MCP_SOCKET_TIMEOUT\` | 20 | Hard socket-level timeout (seconds) |
| \`TRADINGVIEW_MCP_RETRY_DELAYS\` | \`1.0,4.0\` | Comma-separated retry backoff |
| \`TRADINGVIEW_MCP_RETRY_JITTER\` | 0.2 | ±20% jitter on each retry delay |
| \`TRADINGVIEW_MCP_STALE_TTL\` | 21600 | Stale-while-error cache TTL (6 h) |
| \`TRADINGVIEW_MCP_FAILURE_COOLDOWN_S\` | 15 | Wait between retry sequences after a terminal failure |

All tunable; set to \`0\` to disable individual guards.

## Tests

11 new unit tests in \`tests/unit/services/test_screener_provider_resilience.py\` cover:

- Socket default timeout applied at module import
- Empty-body \`JSONDecodeError\` classified as transient (the actual upstream failure mode)
- Socket timeouts classified as transient (was causing 8-min hangs pre-fix)
- Retry-then-succeed path
- Persistent failure raises a \`RuntimeError\` with an actionable message
- Stale-while-error cache returns prior payload when upstream is dead
- Jitter stays within ±band
- Non-transient errors still propagate immediately
- \`resilient_get_multiple_analysis\` uses fresh cache first
- \`resilient_get_multiple_analysis\` passes \`timeout\` explicitly (regression guard for the actual hang fix)
- Stale-on-persistent-failure path for \`resilient_get_multiple_analysis\`

Full suite: **132 passed**.

## Test plan

- [x] \`pytest tests/\` — 132 passed
- [x] Socket default timeout verified applied at import via stress reproduction
- [x] Live upstream cliff: previous 8+ min hang now surfaces clean \`RuntimeError\` with retry suggestion within ~25 s

## Backwards compatibility

No public API changes. All wrapped functions keep their signatures, return shapes, and error contracts. Env defaults are tighter than before but only manifest when upstream is actually misbehaving.

## Related

Split from PR #44 per maintainer request — this is one of three independent fixes. The follow-up PRs add (B) batched-scan fast-fail guards and (C) async hot-path tool conversion. Each can be reviewed and merged independently.