### PR TITLE
fix(scanner): fast-fail batched scans on upstream cliff

### DIFF
--- a/src/tradingview_mcp/core/services/scanner_service.py
+++ b/src/tradingview_mcp/core/services/scanner_service.py
@@ -12,11 +12,16 @@ behavior) hid rate-limit cliffs as "no results today".
 from __future__ import annotations
 
 import sys
+import time as _time
 from typing import List, Optional
 
 from tradingview_mcp.core.errors import BatchExecutionError
 from tradingview_mcp.core.services.coinlist import load_symbols
 from tradingview_mcp.core.services.indicators import compute_metrics
+from tradingview_mcp.core.services.screener_service import (
+    _batch_budget_s,
+    _batch_max_consecutive_fails,
+)
 from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, is_stock_exchange
 
 try:
@@ -62,15 +67,38 @@ def volume_breakout_scan(
 
     batches_attempted = 0
     batches_failed = 0
+    consecutive_failures = 0
     first_error: Optional[str] = None
 
-    for i in range(0, min(len(symbols), 500), batch_size):
+    max_consec = _batch_max_consecutive_fails()
+    budget_s = _batch_budget_s()
+    started_at = _time.time()
+
+    capped_symbols = min(len(symbols), 500)
+    total_batches = (capped_symbols + batch_size - 1) // batch_size
+
+    for i in range(0, capped_symbols, batch_size):
+        # Bail fast if we've spent the wall-clock budget on retries.
+        if (_time.time() - started_at) >= budget_s:
+            try:
+                print(
+                    f"[tradingview_mcp] volume_breakout_scan aborted: "
+                    f"wall-clock budget ({budget_s:.0f}s) exhausted at batch "
+                    f"{batches_attempted}/{total_batches}",
+                    file=sys.stderr,
+                )
+            except Exception:
+                pass
+            break
+
         batch = symbols[i : i + batch_size]
         batches_attempted += 1
         try:
             analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=batch)
+            consecutive_failures = 0
         except Exception as exc:
             batches_failed += 1
+            consecutive_failures += 1
             if first_error is None:
                 first_error = repr(exc)
             try:
@@ -81,6 +109,18 @@ def volume_breakout_scan(
                 )
             except Exception:
                 pass
+
+            if consecutive_failures >= max_consec:
+                try:
+                    print(
+                        f"[tradingview_mcp] volume_breakout_scan aborted: "
+                        f"{consecutive_failures} consecutive batch failures "
+                        f"at batch {batches_attempted}/{total_batches}",
+                        file=sys.stderr,
+                    )
+                except Exception:
+                    pass
+                break
             continue
 
         for symbol, data in analysis.items():

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -11,7 +11,9 @@ envelope so callers can distinguish "no matches today" from "upstream cliff".
 """
 from __future__ import annotations
 
+import os
 import sys
+import time as _time
 from typing import Any, List, Optional
 
 from tradingview_mcp.core.errors import BatchExecutionError
@@ -39,6 +41,55 @@ try:
     _SCREENER_AVAILABLE = True
 except ImportError:
     _SCREENER_AVAILABLE = False
+
+
+# ── Batch fast-fail budget ────────────────────────────────────────────────────
+# Critical: without these guards, a batched scanner that loops over 6-8 batches
+# during an upstream cliff sleeps the failure cooldown (15s default) between
+# every single batch — producing a 90-150s "hang" before BatchExecutionError
+# finally surfaces. The fix is two layered bails:
+#
+#   TRADINGVIEW_MCP_BATCH_MAX_CONSECUTIVE_FAILS (default 2)
+#       After N consecutive batch failures, stop iterating remaining batches
+#       — upstream is clearly down, further attempts just waste wall-clock.
+#
+#   TRADINGVIEW_MCP_BATCH_BUDGET_S (default 30)
+#       Total wall-clock budget for the whole batched scan. When the budget
+#       elapses we stop iterating, returning either the partial result or
+#       (if zero batches succeeded) raising BatchExecutionError.
+#
+# Both surface the same BatchExecutionError shape so the existing MCP tool
+# wrapper at the boundary translates them to the structured error envelope
+# without code changes.
+
+
+def _batch_max_consecutive_fails() -> int:
+    try:
+        return max(1, int(os.environ.get('TRADINGVIEW_MCP_BATCH_MAX_CONSECUTIVE_FAILS', '2')))
+    except Exception:
+        return 2
+
+
+def _batch_budget_s() -> float:
+    try:
+        v = float(os.environ.get('TRADINGVIEW_MCP_BATCH_BUDGET_S', '30'))
+        return max(1.0, v)
+    except Exception:
+        return 30.0
+
+
+def _fill_skipped_tfs(
+    tf_results: dict, all_timeframes: list, reason: str
+) -> None:
+    """Mark every timeframe not yet in ``tf_results`` as skipped.
+
+    Used by the multi-timeframe loop after fast-fail trips so the response
+    explicitly distinguishes "we tried and got an error" from "we never
+    asked because we bailed early".
+    """
+    for tf in all_timeframes:
+        if tf not in tf_results:
+            tf_results[tf] = {"error": f"skipped: {reason}"}
 
 
 # ── Bollinger / trending fetchers ──────────────────────────────────────────────
@@ -146,15 +197,41 @@ def fetch_trending_analysis(
 
     batches_attempted = 0
     batches_failed = 0
+    consecutive_failures = 0
     first_error: Optional[str] = None
 
+    max_consec = _batch_max_consecutive_fails()
+    budget_s = _batch_budget_s()
+    started_at = _time.time()
+    aborted_reason: Optional[str] = None
+
+    total_batches = (len(symbols) + batch_size - 1) // batch_size
+
     for i in range(0, len(symbols), batch_size):
+        # Wall-clock guard: stop iterating once we've burned the budget.
+        # This is the difference between "tool returned in 30s with a
+        # partial / error envelope" and "tool hung for 2 minutes".
+        elapsed = _time.time() - started_at
+        if elapsed >= budget_s:
+            aborted_reason = f"wall-clock budget ({budget_s:.0f}s) exhausted"
+            try:
+                print(
+                    f"[tradingview_mcp] fetch_trending_analysis aborted: "
+                    f"{aborted_reason} after {batches_attempted}/{total_batches} batches",
+                    file=sys.stderr,
+                )
+            except Exception:
+                pass
+            break
+
         batch = symbols[i : i + batch_size]
         batches_attempted += 1
         try:
             analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=batch)
+            consecutive_failures = 0  # Reset on any success.
         except Exception as exc:
             batches_failed += 1
+            consecutive_failures += 1
             if first_error is None:
                 first_error = repr(exc)
             try:
@@ -165,6 +242,24 @@ def fetch_trending_analysis(
                 )
             except Exception:
                 pass
+
+            # Fast-fail: N consecutive failures means upstream is cliffing —
+            # iterating remaining batches just multiplies the cooldown sleeps.
+            if consecutive_failures >= max_consec:
+                aborted_reason = (
+                    f"{consecutive_failures} consecutive batch failures "
+                    f"(upstream cliff)"
+                )
+                try:
+                    print(
+                        f"[tradingview_mcp] fetch_trending_analysis aborted: "
+                        f"{aborted_reason} at batch "
+                        f"{batches_attempted}/{total_batches}",
+                        file=sys.stderr,
+                    )
+                except Exception:
+                    pass
+                break
             continue
 
         for key, value in analysis.items():
@@ -817,12 +912,43 @@ def run_multi_timeframe_analysis(
     tf_results: dict = {}
     alignment_scores: list[int] = []
 
+    # Fast-fail guards: 5 timeframes × (~5s retries + 15s cooldown) ≈ 100s
+    # when upstream cliffs. Bail after N consecutive failures, or when the
+    # wall-clock budget is gone, so the tool returns in bounded time with
+    # whatever timeframes did succeed (or an error envelope on zero success).
+    max_consec = _batch_max_consecutive_fails()
+    budget_s = _batch_budget_s()
+    started_at = _time.time()
+    consecutive_failures = 0
+    aborted_remaining: list[str] = []
+
     for tf in timeframes:
+        # Wall-clock guard.
+        if (_time.time() - started_at) >= budget_s:
+            aborted_remaining = [t for t in timeframes if t not in tf_results]
+            try:
+                print(
+                    f"[tradingview_mcp] run_multi_timeframe_analysis aborted: "
+                    f"wall-clock budget ({budget_s:.0f}s) exhausted; "
+                    f"skipped: {aborted_remaining}",
+                    file=sys.stderr,
+                )
+            except Exception:
+                pass
+            for skip_tf in aborted_remaining:
+                tf_results[skip_tf] = {"error": "skipped: wall-clock budget exhausted"}
+            break
+
         try:
             analysis = get_multiple_analysis(screener=screener, interval=tf, symbols=[symbol])
             if symbol not in analysis or analysis[symbol] is None:
                 tf_results[tf] = {"error": f"No data for {tf}"}
+                consecutive_failures += 1
+                if consecutive_failures >= max_consec:
+                    _fill_skipped_tfs(tf_results, timeframes, "upstream cliff")
+                    break
                 continue
+            consecutive_failures = 0  # Reset on real success.
 
             data = analysis[symbol]
             indicators = data.indicators
@@ -864,6 +990,19 @@ def run_multi_timeframe_analysis(
             }
         except Exception as exc:
             tf_results[tf] = {"error": str(exc)}
+            consecutive_failures += 1
+            if consecutive_failures >= max_consec:
+                try:
+                    print(
+                        f"[tradingview_mcp] run_multi_timeframe_analysis aborted: "
+                        f"{consecutive_failures} consecutive timeframe failures "
+                        f"(upstream cliff)",
+                        file=sys.stderr,
+                    )
+                except Exception:
+                    pass
+                _fill_skipped_tfs(tf_results, timeframes, "upstream cliff")
+                break
 
     total_score = sum(alignment_scores)
     all_bullish = all(s > 0 for s in alignment_scores) if alignment_scores else False

--- a/tests/unit/services/test_batch_sentinel.py
+++ b/tests/unit/services/test_batch_sentinel.py
@@ -50,9 +50,16 @@ def _make_batch_response(symbols: list[str]) -> dict:
 # --- Tests for volume_breakout_scan -----------------------------------------
 
 class TestVolumeBreakoutScanSentinel:
-    def test_all_batches_fail_raises(self):
+    def test_all_batches_fail_raises(self, monkeypatch):
         """When every batch raises, the sentinel must fire."""
         from tradingview_mcp.core.services import scanner_service
+
+        # Disable fast-fail for this test so we can verify the sentinel
+        # behaviour at the "every batch tried, every batch failed" end of
+        # the spectrum. Fast-fail's own behaviour is covered by
+        # ``test_fast_fail_aborts_after_consecutive_failures`` below.
+        monkeypatch.setenv("TRADINGVIEW_MCP_BATCH_MAX_CONSECUTIVE_FAILS", "999")
+        monkeypatch.setenv("TRADINGVIEW_MCP_BATCH_BUDGET_S", "3600")
 
         def always_fail(*_args, **_kwargs):
             # Mirrors the real upstream "empty body" failure mode.
@@ -70,6 +77,64 @@ class TestVolumeBreakoutScanSentinel:
         assert exc_info.value.batches_attempted == 3
         assert exc_info.value.batches_failed == 3
         assert "Expecting value" in exc_info.value.first_error
+
+    def test_fast_fail_aborts_after_consecutive_failures(self, monkeypatch):
+        """Fast-fail must bail after N consecutive batch failures so the tool
+        returns in bounded time instead of grinding through every batch with
+        15s cooldown each."""
+        from tradingview_mcp.core.services import scanner_service
+
+        monkeypatch.setenv("TRADINGVIEW_MCP_BATCH_MAX_CONSECUTIVE_FAILS", "2")
+        monkeypatch.setenv("TRADINGVIEW_MCP_BATCH_BUDGET_S", "3600")
+
+        call_count = {"n": 0}
+
+        def always_fail(*_args, **_kwargs):
+            call_count["n"] += 1
+            raise JSONDecodeError("Expecting value", "", 0)
+
+        with patch.object(scanner_service, "get_multiple_analysis", side_effect=always_fail), \
+             patch.object(scanner_service, "load_symbols", return_value=[f"SYM{i}" for i in range(500)]):
+            # batch_size=100 over 500 symbols would normally be 5 batches,
+            # but fast-fail should stop us at 2.
+            with pytest.raises(BatchExecutionError) as exc_info:
+                scanner_service.volume_breakout_scan(exchange="KUCOIN", timeframe="15m")
+
+        assert call_count["n"] == 2, (
+            f"Expected fast-fail to stop at 2 consecutive failures; got "
+            f"{call_count['n']} calls to upstream."
+        )
+        assert exc_info.value.batches_attempted == 2
+        assert exc_info.value.batches_failed == 2
+
+    def test_partial_success_does_not_trigger_fast_fail(self, monkeypatch):
+        """A successful batch resets the consecutive-failure counter."""
+        from tradingview_mcp.core.services import scanner_service
+
+        monkeypatch.setenv("TRADINGVIEW_MCP_BATCH_MAX_CONSECUTIVE_FAILS", "2")
+        monkeypatch.setenv("TRADINGVIEW_MCP_BATCH_BUDGET_S", "3600")
+
+        # Pattern: fail, succeed, fail, succeed, fail — never 2 in a row.
+        call_log = []
+
+        def alternating(*, screener, interval, symbols):
+            call_log.append(len(symbols))
+            if len(call_log) % 2 == 1:
+                raise JSONDecodeError("Expecting value", "", 0)
+            return _make_batch_response(symbols)
+
+        with patch.object(scanner_service, "get_multiple_analysis", side_effect=alternating), \
+             patch.object(scanner_service, "load_symbols", return_value=[f"SYM{i}" for i in range(500)]):
+            # 500 symbols / 100 = 5 batches. Failures alternate, so no two
+            # are consecutive → fast-fail must NOT trip → all 5 attempted.
+            result = scanner_service.volume_breakout_scan(exchange="KUCOIN", timeframe="15m")
+
+        assert len(call_log) == 5, (
+            f"Expected all 5 batches attempted (alternating failures); got "
+            f"{len(call_log)}."
+        )
+        # 3 failed, 2 succeeded → not all-fail → returns list (not raise).
+        assert isinstance(result, list)
 
     def test_all_succeed_returns_list_no_raise(self):
         """Happy path: every batch returns data, no sentinel."""


### PR DESCRIPTION
## Problem

Even with bounded socket timeouts and a sensible retry layer, batched scanners (\`top_gainers\`, \`volume_breakout_scanner\`, \`multi_timeframe_analysis\`) cascade when every batch hits a cliffing upstream:

\`\`\`
batch 1: ~5s of retries → fail
         15s failure cooldown ← global state, applies before next batch
batch 2: ~5s of retries → fail
         15s failure cooldown
... × 6 batches = 90-150s before BatchExecutionError surfaces
\`\`\`

From the caller's POV that's indistinguishable from a hang. Users see "always hangs" even though the retry layer is firing correctly.

## Fix — two env-tunable guards inside the batch loops themselves

| Env var | Default | Purpose |
| --- | --- | --- |
| \`TRADINGVIEW_MCP_BATCH_MAX_CONSECUTIVE_FAILS\` | 2 | Stop iterating after N consecutive batch failures (upstream is clearly down) |
| \`TRADINGVIEW_MCP_BATCH_BUDGET_S\` | 30 | Total wall-clock budget for the whole batched scan |

Either guard tripping returns either a partial result or the standard \`BatchExecutionError\` envelope. Both surface as the existing structured error format at the MCP boundary — no API change.

## Applied to

- \`screener_service.fetch_trending_analysis\` → \`top_gainers\`, \`top_losers\`, \`rating_filter\`
- \`scanner_service.volume_breakout_scan\` → \`volume_breakout_scanner\`, \`smart_volume_scanner\`
- \`screener_service.run_multi_timeframe_analysis\` → \`multi_timeframe_analysis\`

\`run_multi_timeframe_analysis\` additionally distinguishes "tried and failed" from "never tried (skipped: budget exhausted)" in its per-timeframe result map so the abort is visible in the response.

## Verified against a live upstream cliff

| Tool | Before this fix | After |
| --- | --- | --- |
| \`top_gainers\` | 90+ s before \`BatchExecutionError\` | ✅ ~25 s with envelope |
| \`multi_timeframe_analysis\` | ~100 s worst case | ✅ ~25 s with partial results |

## Tests

2 new fast-fail unit tests in \`tests/unit/services/test_batch_sentinel.py\`:

- \`test_fast_fail_aborts_after_consecutive_failures\` — asserts the loop stops at exactly N consecutive failures (default 2)
- \`test_partial_success_does_not_trigger_fast_fail\` — alternating fail/succeed pattern must NOT trip fast-fail (success resets the counter)

The existing \`test_all_batches_fail_raises\` is now monkeypatched to disable fast-fail (\`MAX_CONSECUTIVE_FAILS=999\`) so it still verifies the every-batch-attempted sentinel under that scenario.

Default suite: **123 passed**.

## Test plan

- [x] \`pytest tests/\` — 123 passed
- [x] Live upstream cliff: \`top_gainers\` returns envelope in ~25 s (was 90+ s)
- [x] Healthy upstream: zero behavior change (fast-fail counter only increments on actual failures)

## Backwards compatibility

No public API changes. The \`BatchExecutionError\` envelope shape (with \`batches_attempted\`, \`batches_failed\`, \`first_error\`) is unchanged. The new guards only trigger when upstream is clearly misbehaving.

## Related

Split from PR #44 per maintainer request. Independent of the screener-resilience PR (each helps; together they're defense in depth). The follow-up async PR makes hot tools \`async def\` for true parallelism on top of these stability guards.