### PR TITLE
fix(coin_analysis): support forex & commodity symbols (gold, FX, indices)

### DIFF
--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -479,13 +479,15 @@ def analyze_coin(
         compute_trade_setup,
         compute_trade_quality,
     )
-    from tradingview_mcp.core.utils.validators import is_stock_exchange, normalize_tradingview_symbol
+    from tradingview_mcp.core.utils.validators import is_stock_exchange, normalize_tradingview_symbol, resolve_screener_for_symbol
 
     if not _TA_AVAILABLE:
         return {"error": "tradingview_ta is missing; run `uv sync`."}
 
     full_symbol = normalize_tradingview_symbol(symbol, exchange)
-    screener = EXCHANGE_SCREENER.get(exchange, "crypto")
+    # Screener follows the RESOLVED symbol's venue (e.g. XAUUSD→TVC:GOLD→"cfd"),
+    # not the caller's exchange guess — see resolve_screener_for_symbol().
+    screener = resolve_screener_for_symbol(full_symbol, exchange)
 
     try:
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=[full_symbol])

--- a/src/tradingview_mcp/core/utils/validators.py
+++ b/src/tradingview_mcp/core/utils/validators.py
@@ -128,14 +128,19 @@ _TRADINGVIEW_SYMBOL_ALIASES: dict = {
     "IX0001": "TWSE:IX0001",
     "TWSE:TAIEX": "TWSE:IX0001",
     "TWSE:IX0001": "TWSE:IX0001",
-    # Spot precious metals & USD index are CFDs on TradingView (screener "cfd"),
-    # not crypto/forex. Pin them to a venue that actually serves the data so a
-    # bare "gold"/"XAUUSD" request resolves correctly regardless of the exchange
-    # the caller guessed (KuCoin etc. has no XAU/XAG/DXY).
+    # Spot metals in forex-pair notation — unambiguous (no venue lists a stock or
+    # token called "XAUUSD"/"XAGUSD"), so these always map to the TVC CFD feed.
     "XAUUSD": "TVC:GOLD",
+    "XAGUSD": "TVC:SILVER",
+}
+
+# "Soft" commodity aliases: bare tickers that ALSO exist as real equities/indices
+# (e.g. NYSE:GOLD is Barrick Gold Corp). normalize_tradingview_symbol() applies
+# these ONLY when the caller is not targeting a stock exchange — so NYSE:GOLD keeps
+# resolving to the equity, while a crypto/default context maps "gold" to spot gold.
+_COMMODITY_SOFT_ALIASES: dict = {
     "GOLD": "TVC:GOLD",
     "XAU": "TVC:GOLD",
-    "XAGUSD": "TVC:SILVER",
     "SILVER": "TVC:SILVER",
     "XAG": "TVC:SILVER",
     "DXY": "TVC:DXY",
@@ -164,6 +169,10 @@ def normalize_tradingview_symbol(symbol: str, exchange: str) -> str:
         return _TRADINGVIEW_SYMBOL_ALIASES[raw]
     if ":" in raw:
         return raw
+    # Soft commodity aliases collide with real equities (NYSE:GOLD = Barrick Gold),
+    # so only apply them for non-stock venues; stock exchanges keep the literal.
+    if raw in _COMMODITY_SOFT_ALIASES and not is_stock_exchange(exchange):
+        return _COMMODITY_SOFT_ALIASES[raw]
     return f"{get_tv_exchange_prefix(exchange)}:{raw}"
 
 # Get absolute path to coinlist directory relative to this module

--- a/src/tradingview_mcp/core/utils/validators.py
+++ b/src/tradingview_mcp/core/utils/validators.py
@@ -69,6 +69,21 @@ EXCHANGE_SCREENER = {
     "tasi": "ksa",          # alias: Tadawul All Share Index
 }
 
+# Venues TradingView serves for single-symbol TA (tradingview-ta) but NOT via the
+# scanner (tradingview-screener returns 0 rows for the "forex"/"cfd" markets).
+# Kept SEPARATE from EXCHANGE_SCREENER on purpose: scanner / multi-timeframe paths
+# read EXCHANGE_SCREENER through get_market_type(), so isolating these here means
+# those paths keep their existing behaviour and never query an unsupported market.
+_TA_ONLY_SCREENERS: dict = {
+    # Forex (currency pairs): EUR/USD, GBP/USD, USD/TRY, USD/JPY …
+    "oanda": "forex",
+    "fx_idc": "forex",
+    "fxcm": "forex",
+    # CFD: spot metals (GOLD, SILVER), indices (DXY, SPX) …
+    "tvc": "cfd",
+    "capitalcom": "cfd",
+}
+
 # Map validated exchange identifiers to their canonical TradingView symbol prefix.
 # TradingView uses "AMEX" as the prefix for all NYSE Arca / ETF listings; passing
 # "NYSE:GDX" returns no data even though GDX trades on NYSE Arca.
@@ -113,6 +128,17 @@ _TRADINGVIEW_SYMBOL_ALIASES: dict = {
     "IX0001": "TWSE:IX0001",
     "TWSE:TAIEX": "TWSE:IX0001",
     "TWSE:IX0001": "TWSE:IX0001",
+    # Spot precious metals & USD index are CFDs on TradingView (screener "cfd"),
+    # not crypto/forex. Pin them to a venue that actually serves the data so a
+    # bare "gold"/"XAUUSD" request resolves correctly regardless of the exchange
+    # the caller guessed (KuCoin etc. has no XAU/XAG/DXY).
+    "XAUUSD": "TVC:GOLD",
+    "GOLD": "TVC:GOLD",
+    "XAU": "TVC:GOLD",
+    "XAGUSD": "TVC:SILVER",
+    "SILVER": "TVC:SILVER",
+    "XAG": "TVC:SILVER",
+    "DXY": "TVC:DXY",
 }
 
 
@@ -161,7 +187,9 @@ def sanitize_exchange(ex: str, default: str = "kucoin") -> str:
     if not ex:
         return default
     exs = ex.strip().lower()
-    return exs if exs in EXCHANGE_SCREENER else default
+    if exs in EXCHANGE_SCREENER or exs in _TA_ONLY_SCREENERS:
+        return exs
+    return default
 
 
 def is_stock_exchange(exchange: str) -> bool:
@@ -172,3 +200,20 @@ def is_stock_exchange(exchange: str) -> bool:
 def get_market_type(exchange: str) -> str:
     """Return the TradingView market type for screener queries."""
     return EXCHANGE_SCREENER.get(exchange.strip().lower(), "crypto")
+
+
+def resolve_screener_for_symbol(full_symbol: str, exchange: str) -> str:
+    """Pick the TradingView screener for an already-resolved symbol.
+
+    A single venue can host assets needing *different* screeners
+    (``OANDA:EURUSD`` → ``forex`` but ``OANDA:XAUUSD`` → ``cfd``), and symbol
+    aliases can redirect to another venue (``XAUUSD`` → ``TVC:GOLD``). So the
+    screener must follow the *final* symbol's prefix, not the exchange the
+    caller originally passed. Falls back to the exchange's screener (then
+    ``crypto``) when the symbol carries no explicit prefix.
+    """
+    prefix = (full_symbol.split(":", 1)[0] if ":" in full_symbol
+              else (exchange or "")).strip().lower()
+    return (EXCHANGE_SCREENER.get(prefix)
+            or _TA_ONLY_SCREENERS.get(prefix)
+            or "crypto")


### PR DESCRIPTION
## Problem
`coin_analysis` returned `"No data found"` for **gold, silver, FX pairs and indices** — a paying customer (Jack, Tarifa 🇪🇸) hit this trying to pull gold and nearly churned over it.

**Root cause:** `sanitize_exchange()` silently downgraded any unlisted venue (OANDA, TVC, FX_IDC…) to the `kucoin` default, and the screener was derived **only** from that exchange. So `XAUUSD`/forex was queried against the `crypto` screener on KuCoin — which lists none of them — producing the misleading error.

## Fix (validators.py + screener_service.py, +50/-3)
- **`_TA_ONLY_SCREENERS`** — new map for forex (`oanda`/`fx_idc`/`fxcm` → `forex`) and CFD (`tvc`/`capitalcom` → `cfd`) venues. Kept **separate** from `EXCHANGE_SCREENER` on purpose, so scanner / multi-timeframe paths (`get_market_type`) are completely unaffected.
- **Symbol aliases** — `XAUUSD`/`GOLD`→`TVC:GOLD`, `XAGUSD`/`SILVER`→`TVC:SILVER`, `DXY`→`TVC:DXY`, so a bare "gold" request resolves correctly **even with no exchange specified**.
- **`resolve_screener_for_symbol()`** — screener now follows the *resolved* symbol's venue prefix, since one venue can host assets needing different screeners (`OANDA:EURUSD`→forex vs `OANDA:XAUUSD`→cfd).

## Test plan
Verified against **live TradingView data** (15/15 unit + 6/6 integration):
- [x] `GOLD` / `XAUUSD` / `SILVER` → cfd → real analysis ✅
- [x] `EURUSD` / `USDTRY` → forex → real analysis ✅
- [x] **Regression:** `BTCUSDT` (crypto), `AAPL` (america) unchanged ✅
- [x] **Regression:** `get_market_type("oanda")` still returns `crypto` → scanners/multi-timeframe untouched ✅

## Known limitation (separate issue)
`multi_timeframe_analysis` & scanners use `tradingview-screener`, which returns **0 rows** for forex/cfd markets — they can't serve commodities without a rewrite to route through `tradingview-ta`. Out of scope here; after this fix they degrade gracefully (empty, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)