### PR TITLE
docs(readme): prominent "not financial advice" disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 **The most complete AI-powered trading toolkit for Claude and MCP clients.**
 Backtesting + Live Sentiment + Yahoo Finance + 30+ Technical Analysis Tools — all in one MCP server.
 
+> [!IMPORTANT]
+> **Not financial advice.** Nothing produced by this software is investment, financial, legal, tax, or accounting advice. tradingview-mcp is an informational and educational analysis tool. Its outputs, including indicators, scores, signals, "trade setups", entries, stop losses, and targets, are computed from third party market data and are **not** recommendations to buy, sell, or hold any asset. It does not execute trades, manage money, or guarantee any result. Trading and investing carry a substantial risk of loss, and you can lose some or all of your capital. Always do your own research and consult a licensed professional before making any financial decision. You are solely responsible for your own decisions and for complying with the laws and regulations that apply to you. Market data may be delayed, inaccurate, or incomplete, and is provided without warranty.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP Ready](https://img.shields.io/badge/MCP-Ready-brightgreen)](https://modelcontextprotocol.com/)


### PR DESCRIPTION
Adds a GitHub `[!IMPORTANT]` callout at the top of the README (right under the tagline, before the badges), so the "not financial advice" notice is impossible to miss. Until now the only disclaimer was a small italic line at the very bottom.

Content: educational/informational tool, outputs are not buy/sell/hold recommendations, executes nothing, guarantees nothing, trading carries risk of loss, user is responsible for their own decisions and local compliance, market data provided without warranty. Mirrors the framing in [anthropics/financial-services](https://github.com/anthropics/financial-services).

Note: this protects the open-source project and self-hosters. The hosted product (pro.cryptosieve.com) still needs its own disclaimer on the landing/footer, at signup, and ideally inside tool output, since that is where payments and the real regulatory exposure live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)