### PR TITLE
docs(readme): make hosted callout prominent ([!TIP] up top)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Backtesting + Live Sentiment + Yahoo Finance + 30+ Technical Analysis Tools — 
 > [!IMPORTANT]
 > **Not financial advice.** Nothing produced by this software is investment, financial, legal, tax, or accounting advice. tradingview-mcp is an informational and educational analysis tool. Its outputs, including indicators, scores, signals, "trade setups", entries, stop losses, and targets, are computed from third party market data and are **not** recommendations to buy, sell, or hold any asset. It does not execute trades, manage money, or guarantee any result. Trading and investing carry a substantial risk of loss, and you can lose some or all of your capital. Always do your own research and consult a licensed professional before making any financial decision. You are solely responsible for your own decisions and for complying with the laws and regulations that apply to you. Market data may be delayed, inaccurate, or incomplete, and is provided without warranty.
 
+> [!TIP]
+> **Skip the setup. Use the hosted version.** [**pro.cryptosieve.com**](https://pro.cryptosieve.com) gives you all 30+ tools as one connector URL for Claude.ai, ChatGPT, Copilot, and Cursor. No `uv`, `pandas`, or Python to wrangle. **$9 per month, with a 7 day free trial.** Self hosting stays free forever; the hosted plan is just for folks who would rather skip the ops.
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MCP Ready](https://img.shields.io/badge/MCP-Ready-brightgreen)](https://modelcontextprotocol.com/)
@@ -28,11 +31,6 @@ Backtesting + Live Sentiment + Yahoo Finance + 30+ Technical Analysis Tools — 
   <img src="https://img.shields.io/badge/💎_Pro_($30)-Sponsor-gold?style=for-the-badge&logo=github-sponsors" alt="Sponsor $30"/>
 </a>
 
-> **🚀 Don't want to fight `uv` / `pandas` / Python on Windows?**  
-> [**pro.cryptosieve.com**](https://pro.cryptosieve.com) — same 30+ tools,  
-> one connector URL into Claude.ai, ChatGPT, Copilot, Cursor. **$9/month** with 7-day free trial.  
-> Self-hosting is free and always will be; the hosted version is just for  
-> folks who'd rather skip the ops dance.
 ---
 
 ## 🎥 Framework Demo


### PR DESCRIPTION
Moves the pro.cryptosieve.com offer from a plain blockquote buried under the sponsor badges to a green `[!TIP]` callout right under the disclaimer and above the badges/sponsorship. Tightened copy, benefit first. The $9/mo recurring offer now sits above the one-time coffee sponsor badges, and the self-hosting-stays-free message is preserved.

Order is now: title, tagline, [!IMPORTANT] disclaimer, [!TIP] hosted, badges, sponsorship, content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)