### PR TITLE
fix(multi_timeframe): forex & gold returned No data on all timeframes

### DIFF
--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -806,7 +806,13 @@ def run_multi_timeframe_analysis(
     if not _TA_AVAILABLE:
         return {"error": "tradingview_ta is missing; run `uv sync`."}
 
-    screener = EXCHANGE_SCREENER.get(exchange, "crypto")
+    # Screener follows the RESOLVED symbol's venue (e.g. XAUUSD→TVC:GOLD→"cfd",
+    # EURUSD→FX_IDC→"forex"), not the caller's exchange guess. Without this,
+    # symbol aliasing redirected gold/FX to TVC: but the screener stayed on the
+    # caller's "crypto" default, so every timeframe returned "No data". This is
+    # the same fix analyze_coin already uses (see resolve_screener_for_symbol).
+    from tradingview_mcp.core.utils.validators import resolve_screener_for_symbol
+    screener = resolve_screener_for_symbol(symbol, exchange)
     timeframes = ["1W", "1D", "4h", "1h", "15m"]
     tf_labels = {
         "1W": "Weekly (Trend Bias)",


### PR DESCRIPTION
## What was broken
`multi_timeframe_analysis` returned `"No data"` on all 5 timeframes for **gold (XAUUSD), silver (XAGUSD), and FX pairs (EURUSD, etc.)**. A paying customer reported it for gold and asked to be told when it's fixed.

## Root cause
`normalize_tradingview_symbol()` correctly aliases `XAUUSD → TVC:GOLD` and `EURUSD → FX_IDC:EURUSD`, but the screener was still derived from the **caller's exchange arg** (`KUCOIN → "crypto"`), so the resolved `TVC:` / `FX_IDC:` symbol was queried against the **crypto** screener — which lists none of those. `coin_analysis` already fixed exactly this in #51 via `resolve_screener_for_symbol()`; the multi-timeframe path was deliberately left unchanged then and kept the bug.

## Fix
One-line behavioural change: derive the screener with `resolve_screener_for_symbol(symbol, exchange)` so it follows the final resolved venue — the same helper `coin_analysis` uses.

## Test (local, live TradingView data)
| symbol | before | after |
|---|---|---|
| XAUUSD | 0/5 TF | **5/5 TF**, price ~4328 |
| EURUSD | 0/5 TF | **5/5 TF** |
| XAGUSD | 0/5 TF | **5/5 TF** |
| BTCUSDT (regression) | 5/5 | 5/5 |
| AAPL (regression) | 5/5 | 5/5 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)