### PR TITLE
Validate capital/cost inputs in backtest tools

### DIFF
--- a/src/tradingview_mcp/core/services/backtest_service.py
+++ b/src/tradingview_mcp/core/services/backtest_service.py
@@ -428,6 +428,41 @@ def _buy_and_hold_return(candles: list[dict]) -> float:
     return round((candles[-1]["close"] - candles[0]["close"]) / candles[0]["close"] * 100, 2)
 
 
+# ─── Numeric input validation ─────────────────────────────────────────────────
+
+# Commission and slippage are per-trade percentages. 100% per side is already
+# absurd, so the cap simply rejects grossly out-of-range inputs (e.g. a value
+# passed in basis points, 250, instead of as a percent, 2.5) before they
+# silently corrupt results.
+_MAX_COST_PCT = 100.0
+
+
+def _validate_numeric_inputs(
+    initial_capital: float,
+    commission_pct: float,
+    slippage_pct: float,
+) -> Optional[str]:
+    """Return an error message if a capital/cost input is out of range, else None.
+
+    Follows the same structured-error convention as the strategy/period checks:
+    callers return ``{"error": msg}`` rather than raising. Without this, two
+    silent-corruption paths are reachable from the public tools:
+
+      * ``initial_capital <= 0`` → division by initial_capital in the trade log,
+        equity curve, and metrics (0 raises ZeroDivisionError; negative flips the
+        sign of every return).
+      * negative ``commission_pct``/``slippage_pct`` → costs become a *credit*,
+        silently inflating every trade's net return above its gross.
+    """
+    if initial_capital <= 0:
+        return f"initial_capital must be positive, got {initial_capital}"
+    if not (0 <= commission_pct <= _MAX_COST_PCT):
+        return f"commission_pct must be between 0 and {_MAX_COST_PCT}, got {commission_pct}"
+    if not (0 <= slippage_pct <= _MAX_COST_PCT):
+        return f"slippage_pct must be between 0 and {_MAX_COST_PCT}, got {slippage_pct}"
+    return None
+
+
 # ─── Public API: run_backtest ─────────────────────────────────────────────────
 
 def run_backtest(
@@ -451,6 +486,10 @@ def run_backtest(
         return {"error": f"Invalid period '{period}'. Choose: {', '.join(_VALID_PERIODS)}"}
     if interval not in _VALID_INTERVALS:
         return {"error": f"Invalid interval '{interval}'. Choose: 1d or 1h"}
+
+    num_err = _validate_numeric_inputs(initial_capital, commission_pct, slippage_pct)
+    if num_err:
+        return {"error": num_err}
 
     try:
         candles = _fetch_ohlcv(symbol, period, interval)
@@ -516,6 +555,10 @@ def compare_strategies(
     interval = interval.lower().strip()
     if interval not in _VALID_INTERVALS:
         return {"error": f"Invalid interval '{interval}'. Choose: 1d or 1h"}
+
+    num_err = _validate_numeric_inputs(initial_capital, commission_pct, slippage_pct)
+    if num_err:
+        return {"error": num_err}
 
     try:
         candles = _fetch_ohlcv(symbol, period, interval)
@@ -623,6 +666,10 @@ def walk_forward_backtest(
                           f"(~{_SMA200_MIN_BARS} bars) which exceeds typical "
                           f"walk-forward fold sizes. Use run_backtest with "
                           f"period='2y' instead, or pick a shorter-warmup strategy.")}
+
+    num_err = _validate_numeric_inputs(initial_capital, commission_pct, slippage_pct)
+    if num_err:
+        return {"error": num_err}
 
     try:
         candles = _fetch_ohlcv(symbol, period, interval)

--- a/tests/unit/services/test_backtest_validation.py
+++ b/tests/unit/services/test_backtest_validation.py
@@ -1,0 +1,71 @@
+"""Unit tests for backtest numeric-input validation.
+
+These cover the capital/cost guards added to the public backtest API. They are
+network-free on purpose: each guard runs *before* `_fetch_ohlcv`, so passing a
+valid strategy/period/interval with an out-of-range numeric input returns a
+structured error without ever hitting Yahoo Finance.
+"""
+from tradingview_mcp.core.services.backtest_service import (
+    _validate_numeric_inputs,
+    run_backtest,
+    walk_forward_backtest,
+    compare_strategies,
+)
+
+
+# ─── helper: _validate_numeric_inputs ─────────────────────────────────────────
+
+def test_valid_inputs_pass():
+    assert _validate_numeric_inputs(10_000.0, 0.1, 0.05) is None
+
+
+def test_zero_capital_rejected():
+    msg = _validate_numeric_inputs(0.0, 0.1, 0.05)
+    assert msg is not None and "initial_capital" in msg
+
+
+def test_negative_capital_rejected():
+    msg = _validate_numeric_inputs(-100.0, 0.1, 0.05)
+    assert msg is not None and "initial_capital" in msg
+
+
+def test_negative_commission_rejected():
+    # Negative cost would credit the account every trade, inflating returns.
+    msg = _validate_numeric_inputs(10_000.0, -0.1, 0.05)
+    assert msg is not None and "commission_pct" in msg
+
+
+def test_negative_slippage_rejected():
+    msg = _validate_numeric_inputs(10_000.0, 0.1, -0.05)
+    assert msg is not None and "slippage_pct" in msg
+
+
+def test_absurd_cost_rejected():
+    # Out of range: a value passed in basis points (250) instead of percent (2.5).
+    msg = _validate_numeric_inputs(10_000.0, 250.0, 0.05)
+    assert msg is not None and "commission_pct" in msg
+
+
+def test_cost_boundaries_inclusive():
+    assert _validate_numeric_inputs(10_000.0, 0.0, 0.0) is None
+    assert _validate_numeric_inputs(10_000.0, 100.0, 100.0) is None
+
+
+# ─── boundary: public API returns error before any network call ───────────────
+
+def test_run_backtest_rejects_bad_capital_offline():
+    out = run_backtest("BTC-USD", "rsi", period="1y", interval="1d",
+                       initial_capital=0.0)
+    assert "error" in out and "initial_capital" in out["error"]
+
+
+def test_walk_forward_rejects_negative_commission_offline():
+    out = walk_forward_backtest("BTC-USD", "rsi", period="2y", interval="1d",
+                                commission_pct=-0.1)
+    assert "error" in out and "commission_pct" in out["error"]
+
+
+def test_compare_strategies_rejects_bad_capital_offline():
+    out = compare_strategies("BTC-USD", period="1y", interval="1d",
+                             initial_capital=-5.0)
+    assert "error" in out and "initial_capital" in out["error"]


### PR DESCRIPTION
While poking around the backtest tools I noticed the input validation stops at `strategy` / `period` / `interval` / `n_splits` / `train_ratio` and never checks the numeric ones. That leaves a couple of ways to get silently wrong results, so this adds a guard for `initial_capital`, `commission_pct` and `slippage_pct`.

Two cases that bit me:

- `initial_capital <= 0` divides through in the trade log, equity curve and metrics. Passing `0` throws a raw `ZeroDivisionError`, and a negative value quietly flips the sign of every return.
- A negative `commission_pct` or `slippage_pct` turns the cost into a credit — `_apply_costs` does `(commission_pct + slippage_pct) * 2`, so a fat-finger like `-0.1` makes net return come out *above* gross. The backtest just looks better than it is, no warning.

It's the same "fail loud instead of returning garbage" idea behind #60, except on params that actually exist in the current API (that issue's `start_date`/`end_date` aren't real params on these tools — see my comment there).

The fix is a small `_validate_numeric_inputs()` helper called in `run_backtest`, `compare_strategies` and `walk_forward_backtest`, right after the existing `interval` check and before any data fetch. It returns the same `{"error": ...}` shape the other guards use — no new error style, and it short-circuits before hitting Yahoo so it costs nothing on the happy path.

Tests are in `tests/unit/services/test_backtest_validation.py` — 10 of them, all offline since the guard runs before the network call. `pytest` on that file is green (`10 passed`). Valid inputs behave exactly as before.

Heads up: the suite currently has 7 failing tests in `test_batch_sentinel.py` (looks like a `screener_service.get_multiple_analysis` mock target that no longer exists) — those fail on a clean `main` too, nothing to do with this change.
