### PR TITLE
docs: clarify the server does not use or risk your TradingView account

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Backtesting + live sentiment + Yahoo Finance + 30+ technical-analysis tools — 
 > [!NOTE]
 > Independent open-source project — **not affiliated with, endorsed by, or associated with TradingView Inc.** "TradingView" is a trademark of its respective owner; this project consumes third-party market data and is not a TradingView product.
 
+> [!NOTE]
+> **Does it need — or risk — your TradingView account? No.** This server does **not** log into, scrape, or automate a TradingView session, and it requires no TradingView account or API key. Market data is fetched server-side from public endpoints, so there is no account of yours in the loop and no browser/UI automation. *(This is different from MCP servers that drive the TradingView Desktop app via Chrome DevTools.)* You are responsible for ensuring your own use complies with the terms of any data source you point it at.
+
 > [!IMPORTANT]
 > **Not financial advice.** Nothing produced by this software is investment, financial, legal, tax, or accounting advice. tradingview-mcp is an informational and educational analysis tool. Its outputs, including indicators, scores, signals, "trade setups", entries, stop losses, and targets, are computed from third party market data and are **not** recommendations to buy, sell, or hold any asset. It does not execute trades, manage money, or guarantee any result. Trading and investing carry a substantial risk of loss, and you can lose some or all of your capital. Always do your own research and consult a licensed professional before making any financial decision. You are solely responsible for your own decisions and for complying with the laws and regulations that apply to you. Market data may be delayed, inaccurate, or incomplete, and is provided without warranty.
 


### PR DESCRIPTION
Recurring question (e.g. on r/TradingView): *does using this MCP risk getting my TradingView account banned?*

It doesn't — this server never logs into, scrapes, or automates a TradingView session and needs no TradingView account or API key; market data is fetched server-side from public endpoints. This adds a short NOTE near the existing 'not affiliated' disclaimer that:
- states there's no account/login in the loop (nothing to ban),
- distinguishes this from MCP servers that drive the TradingView Desktop app via Chrome DevTools,
- adds a user-responsibility line on complying with any data source's terms.

Docs-only.