### PR TITLE
fix(scanner): volume_confirmation_analysis sent bare crypto symbols (~99% failures)

### DIFF
--- a/src/tradingview_mcp/core/services/scanner_service.py
+++ b/src/tradingview_mcp/core/services/scanner_service.py
@@ -22,7 +22,11 @@ from tradingview_mcp.core.services.screener_service import (
     _batch_budget_s,
     _batch_max_consecutive_fails,
 )
-from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, is_stock_exchange
+from tradingview_mcp.core.utils.validators import (
+    EXCHANGE_SCREENER,
+    normalize_tradingview_symbol,
+    resolve_screener_for_symbol,
+)
 
 try:
     # Patched: route through resilience layer (retry + 60s TTL cache).
@@ -206,18 +210,15 @@ def volume_confirmation_analyze(
     Returns:
         Dict with price data, volume analysis, technical indicators, and signals.
     """
-    # Normalise symbol
-    if not is_stock_exchange(exchange) and not symbol.upper().endswith("USDT"):
-        symbol = symbol.upper() + "USDT"
-    else:
-        symbol = symbol.upper()
-
-    if is_stock_exchange(exchange) and ":" not in symbol:
-        full_symbol = f"{exchange.upper()}:{symbol}"
-    else:
-        full_symbol = symbol
-
-    screener = EXCHANGE_SCREENER.get(exchange, "crypto")
+    # Resolve to a fully-qualified EXCHANGE:TICKER via the canonical helper — the
+    # exact path analyze_coin() (coin_analysis) uses. The old hand-rolled
+    # normalisation only prefixed the venue for STOCK exchanges, so every crypto
+    # symbol reached tradingview_ta as a bare ticker (e.g. "BTCUSDT") and was
+    # rejected with "Symbol should be a list of exchange and ticker" — ~99% of
+    # volume_confirmation_analysis calls failed. This also fixes forex/commodity
+    # symbols (XAUUSD -> TVC:GOLD) and picks the screener from the resolved venue.
+    full_symbol = normalize_tradingview_symbol(symbol, exchange)
+    screener = resolve_screener_for_symbol(full_symbol, exchange)
 
     try:
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=[full_symbol])

--- a/tests/unit/test_exchange_fixes.py
+++ b/tests/unit/test_exchange_fixes.py
@@ -143,3 +143,48 @@ class TestSymbolConstruction:
     def test_unknown_exchange_still_falls_back_to_kucoin(self):
         """Unrecognised exchange falls back to KUCOIN default then gets KUCOIN prefix."""
         assert self._build_symbol("INVALID", "GDX") == "KUCOIN:GDX"
+
+
+# ── Bug 3 fix: volume_confirmation_analyze sent bare crypto symbols ────────────
+# It hand-rolled symbol normalisation and only prefixed the venue for STOCK
+# exchanges, so crypto symbols reached tradingview_ta as a bare ticker
+# ("BTCUSDT") and were rejected — ~99% of volume_confirmation_analysis calls
+# failed. It now uses the canonical normalize_tradingview_symbol() like
+# analyze_coin(). These tests capture the symbol actually sent upstream (no
+# network) and assert it is fully qualified.
+
+class TestVolumeConfirmationSymbolPrefix:
+    @staticmethod
+    def _capture(symbol, exchange):
+        import tradingview_mcp.core.services.scanner_service as svc
+        seen = {}
+
+        def fake_gma(screener, interval, symbols):
+            seen["symbols"] = symbols
+            seen["screener"] = screener
+            return {}  # empty -> function returns a "No data" envelope after the call
+
+        orig = svc.get_multiple_analysis
+        svc.get_multiple_analysis = fake_gma
+        try:
+            svc.volume_confirmation_analyze(symbol, exchange, "15m")
+        finally:
+            svc.get_multiple_analysis = orig
+        return seen
+
+    def test_crypto_symbol_is_venue_prefixed(self):
+        seen = self._capture("BTCUSDT", "KUCOIN")
+        assert seen["symbols"] == ["KUCOIN:BTCUSDT"]  # not bare "BTCUSDT"
+        assert seen["screener"] == "crypto"
+
+    def test_stock_symbol_is_venue_prefixed(self):
+        seen = self._capture("AAPL", "NASDAQ")
+        assert seen["symbols"] == ["NASDAQ:AAPL"]
+        assert seen["screener"] == "america"
+
+    def test_commodity_alias_resolves(self):
+        # XAUUSD must resolve to the TradingView commodity symbol, not get a
+        # spurious USDT suffix (the old code did "XAUUSD" -> "XAUUSDUSDT").
+        seen = self._capture("XAUUSD", "KUCOIN")
+        assert seen["symbols"] == ["TVC:GOLD"]
+        assert seen["screener"] == "cfd"


### PR DESCRIPTION
## Problem
Live gateway telemetry (`tool_events`) flagged **`volume_confirmation_analysis` failing ~99% of the time** — 260 of 263 calls over 7 days — with:

> `Analysis failed: One or more symbol is invalid. Symbol should be a list of exchange and ticker symbol(s).`

It was a top error source across the coin/scan tools (overall error rate had crept from ~3.8% / 30d to ~7.3% / 1d as this tool's usage rose).

## Root cause
`volume_confirmation_analyze()` (`scanner_service.py`) hand-rolled symbol normalisation and only added the venue prefix for **stock** exchanges:

```python
if is_stock_exchange(exchange) and ":" not in symbol:
    full_symbol = f"{exchange.upper()}:{symbol}"
else:
    full_symbol = symbol          # crypto -> bare "BTCUSDT", no exchange prefix
```

So every crypto call sent a bare ticker to `tradingview_ta`, which requires `EXCHANGE:TICKER` and rejected it. (`analyze_coin()` / `coin_analysis` was unaffected — it already uses the canonical helper.)

## Fix
Use the canonical `normalize_tradingview_symbol()` + `resolve_screener_for_symbol()` — the exact path `analyze_coin()` uses:
- adds the venue prefix for crypto (`KUCOIN:BTCUSDT`),
- resolves index/commodity aliases (`XAUUSD → TVC:GOLD`, instead of the old `XAUUSDUSDT`),
- picks the screener from the resolved venue.

Net diff is small; it deletes the divergent hand-rolled block and removes the now-unused `is_stock_exchange` import.

## Verification
- **Live:** `volume_confirmation_analyze('BTCUSDT','KUCOIN','15m')` now returns full data (price/volume/indicators/signals) — no symbol error.
- **Tests:** existing suite green (70 passed); added 3 network-free regression tests (`TestVolumeConfirmationSymbolPrefix`) asserting the symbol sent upstream is venue-prefixed for crypto & stock and that commodity aliases resolve. `test_exchange_fixes.py`: 35 passed.