### PR TITLE
fix(errors): stop raw JSONDecodeError leaking into tool error envelopes

### DIFF
--- a/src/tradingview_mcp/core/services/scanner_service.py
+++ b/src/tradingview_mcp/core/services/scanner_service.py
@@ -33,6 +33,7 @@ try:
     import tradingview_ta  # noqa: F401  presence check
     from tradingview_mcp.core.services.screener_provider import (
         resilient_get_multiple_analysis as get_multiple_analysis,
+        humanize_upstream_error,
     )
     _TA_AVAILABLE = True
 except ImportError:
@@ -300,7 +301,7 @@ def volume_confirmation_analyze(
             },
         }
     except Exception as exc:
-        return {"error": f"Analysis failed: {exc}"}
+        return {"error": f"Analysis failed: {humanize_upstream_error(exc)}"}
 
 
 # ── Smart volume scanner ───────────────────────────────────────────────────────

--- a/src/tradingview_mcp/core/services/screener_provider.py
+++ b/src/tradingview_mcp/core/services/screener_provider.py
@@ -313,6 +313,23 @@ def _format_transient_error(last_exc: BaseException, attempts: int, total_wait: 
     )
 
 
+def humanize_upstream_error(exc: BaseException) -> str:
+    """Normalise an exception for a USER-FACING error envelope.
+
+    Both resilience wrappers already emit a clean terminal message, but a raw
+    ``json.JSONDecodeError`` ("Expecting value: line 1 column 1 (char 0)") can
+    still escape a non-wrapped sub-call and surface verbatim through a tool's
+    outer ``except`` handler. Collapse those transient upstream errors into a
+    plain retry hint; pass our already-clean message and genuine errors (e.g.
+    "invalid symbol") through unchanged so real problems stay diagnosable."""
+    msg = str(exc)
+    if msg.startswith("Upstream TradingView scanner returned transient"):
+        return msg  # already our clean terminal message
+    if _is_transient_screener_error(exc):
+        return "TradingView data is temporarily unavailable — please retry in a moment."
+    return msg
+
+
 def _scan_with_retry(q, cookies=None, cache_key: Optional[Tuple] = None):
     """Wrap Query.get_scanner_data with retries on transient TV outages.
     Returns (total, df). Re-raises on non-transient errors or on final failure.

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -26,7 +26,7 @@ from tradingview_mcp.core.services.indicators import compute_metrics
 from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type
 
 # Resilience layer (does not require tradingview_ta; safe to import unconditionally).
-from tradingview_mcp.core.services.screener_provider import _scan_with_retry
+from tradingview_mcp.core.services.screener_provider import _scan_with_retry, humanize_upstream_error
 
 try:
     # Patched: route through resilience layer (retry + 60s TTL cache).
@@ -128,7 +128,7 @@ def fetch_bollinger_analysis(
     try:
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=symbols)
     except Exception as exc:
-        raise RuntimeError(f"Analysis failed: {exc}") from exc
+        raise RuntimeError(f"Analysis failed: {humanize_upstream_error(exc)}") from exc
 
     rows: List[Row] = []
     for key, value in analysis.items():
@@ -699,7 +699,7 @@ def analyze_coin(
             **trade_data,
         }
     except Exception as exc:
-        return {"error": f"Analysis failed: {exc}", "symbol": symbol, "exchange": exchange, "timeframe": timeframe}
+        return {"error": f"Analysis failed: {humanize_upstream_error(exc)}", "symbol": symbol, "exchange": exchange, "timeframe": timeframe}
 
 
 # ── Consecutive candle pattern scan ────────────────────────────────────────────
@@ -739,7 +739,7 @@ def scan_consecutive_candles(
     try:
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=symbols)
     except Exception as exc:
-        return {"error": f"Pattern analysis failed: {exc}", "exchange": exchange, "timeframe": timeframe}
+        return {"error": f"Pattern analysis failed: {humanize_upstream_error(exc)}", "exchange": exchange, "timeframe": timeframe}
 
     pattern_coins: list[dict] = []
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -102,3 +102,35 @@ class TestBatchExecutionError:
     def test_is_a_real_exception(self):
         with pytest.raises(BatchExecutionError):
             raise BatchExecutionError(1, 1, "x")
+
+
+# ── humanize_upstream_error: no raw JSONDecodeError in user-facing envelopes ──
+# Both resilience wrappers emit a clean terminal message, but a raw
+# json.JSONDecodeError ("Expecting value: line 1 column 1 (char 0)") could
+# escape a non-wrapped sub-call and surface verbatim through a tool's outer
+# `except`. The user-facing boundary now normalises those.
+
+class TestHumanizeUpstreamError:
+    @staticmethod
+    def _h(exc):
+        from tradingview_mcp.core.services.screener_provider import humanize_upstream_error
+        return humanize_upstream_error(exc)
+
+    def test_raw_jsondecodeerror_becomes_clean_hint(self):
+        import json
+        msg = self._h(json.JSONDecodeError("Expecting value", "", 0))
+        assert "Expecting value" not in msg
+        assert "temporarily unavailable" in msg
+
+    def test_socket_timeout_becomes_clean_hint(self):
+        import socket
+        assert "temporarily unavailable" in self._h(socket.timeout("timed out"))
+
+    def test_already_clean_terminal_message_passes_through(self):
+        clean = "Upstream TradingView scanner returned transient errors on all 3 attempts spanning 12s (...)"
+        assert self._h(RuntimeError(clean)) == clean
+
+    def test_genuine_error_passes_through(self):
+        # Real, actionable errors (e.g. invalid symbol) must stay diagnosable.
+        real = "One or more symbol is invalid. Symbol should be a list of exchange and ticker"
+        assert self._h(ValueError(real)) == real


### PR DESCRIPTION
## Problem
Live telemetry: ~**181/30d** user-facing errors read literally
`Analysis failed: Expecting value: line 1 column 1 (char 0)` — a raw
`json.JSONDecodeError` from an empty TradingView scanner body, relayed verbatim to the AI client/user.

Both resilience wrappers (`_scan_with_retry`, `resilient_get_multiple_analysis`) already format a clean terminal message on exhaustion, but a transient JSON error from a **non-wrapped sub-call** can still escape through a tool's outer `except` handler (`f"Analysis failed: {exc}"`).

## Fix
Normalise at the **user-facing boundary** (defense-in-depth — a tool envelope should never leak a raw internal parser exception):
- Add `humanize_upstream_error(exc)` in `screener_provider.py` (reuses `_is_transient_screener_error`).
- Apply it where tools build their error envelope: `analyze_coin`, `scan_consecutive_candles`, the screen-by-rating path, and `smart_volume_scan`.

Behaviour:
- raw `JSONDecodeError` / `"Expecting value"` / socket timeout → `TradingView data is temporarily unavailable — please retry in a moment.`
- our already-clean wrapper message → **passthrough**
- genuine errors (e.g. *invalid symbol*) → **passthrough** (stay diagnosable)

## Scope / honesty
Cosmetic — this does **not** reduce the error count (the underlying TradingView transient failures are a data-source issue, addressed separately by the licensed-data migration). It makes those failures read cleanly instead of as a raw parser exception.

## Tests
+4 regression tests (`TestHumanizeUpstreamError`); full unit suite **141 passed**.