### PR TITLE
fix(trading): clear error for missing symbol arg instead of IndexError

### DIFF
--- a/openclaw/trading.py
+++ b/openclaw/trading.py
@@ -43,33 +43,49 @@ except ImportError as e:
 cmd = sys.argv[1] if len(sys.argv) > 1 else "help"
 args = sys.argv[2:]
 
+
+def _require_symbol():
+    """Return the first positional (symbol) argument.
+
+    Emits a clear operator-facing error and exits non-zero when it is missing,
+    instead of letting ``args[0]`` raise an opaque IndexError.
+    """
+    if not args:
+        print(json.dumps({
+            "error": f"Missing required symbol argument for '{cmd}'. "
+                     f"Run 'trading.py help' for usage."
+        }))
+        sys.exit(1)
+    return args[0]
+
+
 try:
     if cmd == "price":
-        print(json.dumps(get_price(args[0]), indent=2))
+        print(json.dumps(get_price(_require_symbol()), indent=2))
 
     elif cmd == "snapshot":
         print(json.dumps(get_market_snapshot(), indent=2))
 
     elif cmd == "backtest":
-        symbol   = args[0]
+        symbol   = _require_symbol()
         strategy = args[1] if len(args) > 1 else "rsi"
         period   = args[2] if len(args) > 2 else "1y"
         interval = args[3] if len(args) > 3 else "1d"
         print(json.dumps(run_backtest(symbol, strategy, period, interval=interval), indent=2))
 
     elif cmd == "compare":
-        symbol = args[0]
+        symbol = _require_symbol()
         period = args[1] if len(args) > 1 else "1y"
         print(json.dumps(compare_strategies(symbol, period), indent=2))
 
     elif cmd == "walkforward":
-        symbol   = args[0]
+        symbol   = _require_symbol()
         strategy = args[1] if len(args) > 1 else "rsi"
         period   = args[2] if len(args) > 2 else "2y"
         print(json.dumps(walk_forward_backtest(symbol, strategy, period), indent=2))
 
     elif cmd == "sentiment":
-        print(json.dumps(analyze_sentiment(args[0]), indent=2))
+        print(json.dumps(analyze_sentiment(_require_symbol()), indent=2))
 
     elif cmd == "help":
         print("Commands: price <sym> | snapshot | backtest <sym> <strategy> <period> [interval] | compare <sym> [period] | walkforward <sym> [strategy] [period] | sentiment <sym>")


### PR DESCRIPTION
## Summary
Commands that need a symbol (`price`, `backtest`, `compare`, `walkforward`, `sentiment`) read `args[0]` without checking that it exists. Running e.g. `python3 trading.py price` with no symbol raises `IndexError`, which the catch-all handler surfaces as the opaque `{"error": "list index out of range"}`. This adds a small guard that returns a clear, actionable error and a non-zero exit code.

## Why it matters
The OpenClaw agent invokes this wrapper via bash; on a missing argument it currently gets a cryptic `list index out of range` message and a success (`0`) exit status, so the caller cannot tell it passed bad input versus getting real data.

## Testing
This patch was produced from static analysis of the dispatcher, not from executing the CLI: every `args[0]` read was traced and replaced with `_require_symbol()`, which returns `args[0]` unchanged whenever an argument is present, so valid invocations keep identical behavior by construction. The original failure is reproducible with `python3 trading.py price` (no argument).
