### PR TITLE
fix(errors): retryability-signaled envelopes + symbol suggestions + tool-name anchoring

### DIFF
--- a/src/tradingview_mcp/core/services/coinlist.py
+++ b/src/tradingview_mcp/core/services/coinlist.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os
-from typing import List
+from functools import lru_cache
+from typing import Dict, FrozenSet, List
 from ..utils.validators import COINLIST_DIR
 
 
@@ -29,3 +30,61 @@ def load_symbols(exchange: str) -> List[str]:
     
     # If all fails, return empty list
     return []
+
+
+# "all.txt" is an aggregate of every exchange — suggesting it as an exchange
+# would send the model straight back into an invalid `exchange` value.
+_SUGGESTION_EXCLUDE = {"all"}
+
+
+@lru_cache(maxsize=1)
+def _coinlist_index() -> Dict[str, FrozenSet[str]]:
+    """EXCHANGE (upper) -> frozenset of its listed symbols, from local files.
+
+    Built once per process (the coinlist directory ships with the package and
+    doesn't change at runtime). Used only on error paths, so the one-time
+    directory scan is not on any hot path.
+    """
+    index: Dict[str, FrozenSet[str]] = {}
+    try:
+        names = os.listdir(COINLIST_DIR)
+    except OSError:
+        return index
+    for name in names:
+        if not name.endswith(".txt"):
+            continue
+        exch = name[:-4]
+        if exch.lower() in _SUGGESTION_EXCLUDE:
+            continue
+        try:
+            with open(os.path.join(COINLIST_DIR, name), "r", encoding="utf-8") as f:
+                # Lines ship as "EXCHANGE:TICKER" (e.g. "KUCOIN:HYPEUSDT");
+                # index the bare ticker so lookups match either input form.
+                symbols = frozenset(
+                    line.strip().upper().split(":")[-1]
+                    for line in f
+                    if line.strip()
+                )
+        except (OSError, UnicodeDecodeError):
+            continue
+        if symbols:
+            index[exch.upper()] = symbols
+    return index
+
+
+def exchanges_listing_symbol(symbol: str, max_results: int = 6) -> List[str]:
+    """Exchanges (per the local coinlists) where *symbol* is listed.
+
+    Zero network cost — reads only the bundled coinlist files. Accepts bare
+    tickers ("HYPEUSDT") or prefixed ones ("BINANCE:HYPEUSDT"). Returns
+    exchange names sorted alphabetically, capped at *max_results*; empty list
+    when the ticker appears in no local list (likely a typo or an unsupported
+    venue).
+    """
+    bare = symbol.strip().upper().split(":")[-1]
+    if not bare:
+        return []
+    matches = sorted(
+        exch for exch, symbols in _coinlist_index().items() if bare in symbols
+    )
+    return matches[:max_results]

--- a/src/tradingview_mcp/core/services/scanner_service.py
+++ b/src/tradingview_mcp/core/services/scanner_service.py
@@ -15,13 +15,14 @@ import sys
 import time as _time
 from typing import List, Optional
 
-from tradingview_mcp.core.errors import BatchExecutionError
+from tradingview_mcp.core.errors import BatchExecutionError, ErrorCode, make_error
 from tradingview_mcp.core.services.coinlist import load_symbols
-from tradingview_mcp.core.services.indicators import compute_metrics
 from tradingview_mcp.core.services.screener_service import (
     _batch_budget_s,
     _batch_max_consecutive_fails,
+    symbol_not_found_error,
 )
+from tradingview_mcp.core.services.indicators import compute_metrics
 from tradingview_mcp.core.utils.validators import (
     EXCHANGE_SCREENER,
     normalize_tradingview_symbol,
@@ -224,11 +225,21 @@ def volume_confirmation_analyze(
     try:
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=[full_symbol])
         if not analysis or full_symbol not in analysis:
-            return {"error": f"No data found for {full_symbol}"}
+            return symbol_not_found_error(
+                symbol, exchange, timeframe=timeframe, full_symbol=full_symbol
+            )
 
         data = analysis[full_symbol]
         if not data or not hasattr(data, "indicators"):
-            return {"error": f"No indicator data for {full_symbol}"}
+            return make_error(
+                ErrorCode.NO_DATA,
+                f"No indicator data for {full_symbol}. The venue returned a row "
+                "without indicators — retrying the same request will not help; "
+                "try another timeframe or exchange.",
+                retryable=False,
+                symbol=symbol, exchange=exchange, timeframe=timeframe,
+                full_symbol=full_symbol,
+            )
 
         ind = data.indicators
         volume = ind.get("volume", 0)
@@ -301,7 +312,12 @@ def volume_confirmation_analyze(
             },
         }
     except Exception as exc:
-        return {"error": f"Analysis failed: {humanize_upstream_error(exc)}"}
+        return make_error(
+            ErrorCode.UPSTREAM_ERROR,
+            f"Analysis failed: {humanize_upstream_error(exc)}",
+            retryable=True, retry_after_s=60,
+            symbol=symbol, exchange=exchange, timeframe=timeframe,
+        )
 
 
 # ── Smart volume scanner ───────────────────────────────────────────────────────

--- a/src/tradingview_mcp/core/services/screener_service.py
+++ b/src/tradingview_mcp/core/services/screener_service.py
@@ -16,12 +16,12 @@ import sys
 import time as _time
 from typing import Any, List, Optional
 
-from tradingview_mcp.core.errors import BatchExecutionError
+from tradingview_mcp.core.errors import BatchExecutionError, ErrorCode, make_error
 from tradingview_mcp.core.types import (
     IndicatorMap, MultiRow, Row,
     percent_change, tf_to_tv_resolution,
 )
-from tradingview_mcp.core.services.coinlist import load_symbols
+from tradingview_mcp.core.services.coinlist import exchanges_listing_symbol, load_symbols
 from tradingview_mcp.core.services.indicators import compute_metrics
 from tradingview_mcp.core.utils.validators import EXCHANGE_SCREENER, get_market_type
 
@@ -568,6 +568,35 @@ def fetch_multi_timeframe_patterns(
 
 # ── Coin analysis (single asset) ───────────────────────────────────────────────
 
+def symbol_not_found_error(symbol: str, exchange: str, **context: Any) -> dict:
+    """SYMBOL_NOT_FOUND envelope with actionable, locally-sourced suggestions.
+
+    Telemetry showed agents retrying the exact same not-found request dozens
+    of times (e.g. HYPEUSDT on BINANCE) because the old bare-string error gave
+    no retryability signal and no alternative. This envelope says explicitly:
+    not retryable here, but *these* exchanges list the ticker (from the bundled
+    coinlists — zero network cost).
+    """
+    listed_on = exchanges_listing_symbol(symbol)
+    message = f"No data found for {symbol} on {exchange}."
+    if listed_on:
+        message += (
+            " Retrying on this exchange will fail again; the symbol is listed on: "
+            + ", ".join(listed_on)
+            + ". Retry with one of those as `exchange`."
+        )
+    else:
+        message += (
+            " No local listing found on any supported exchange — verify the ticker"
+            " spelling; retrying the same request will return the same error."
+        )
+    return make_error(
+        ErrorCode.SYMBOL_NOT_FOUND, message,
+        retryable=False, symbol=symbol, exchange=exchange, listed_on=listed_on,
+        **context,
+    )
+
+
 def analyze_coin(
     symbol: str,
     exchange: str,
@@ -606,7 +635,7 @@ def analyze_coin(
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=[full_symbol])
 
         if full_symbol not in analysis or analysis[full_symbol] is None:
-            return {"error": f"No data found for {symbol} on {exchange}", "symbol": symbol, "exchange": exchange, "timeframe": timeframe}
+            return symbol_not_found_error(symbol, exchange, timeframe=timeframe)
 
         data = analysis[full_symbol]
         indicators = data.indicators
@@ -699,7 +728,15 @@ def analyze_coin(
             **trade_data,
         }
     except Exception as exc:
-        return {"error": f"Analysis failed: {humanize_upstream_error(exc)}", "symbol": symbol, "exchange": exchange, "timeframe": timeframe}
+        # Transient upstream outages (TradingView's 30-90s empty-body cliffs)
+        # dominate this path — signal machine-readable retryability so agents
+        # wait-and-retry instead of hammering or giving up.
+        return make_error(
+            ErrorCode.UPSTREAM_ERROR,
+            f"Analysis failed: {humanize_upstream_error(exc)}",
+            retryable=True, retry_after_s=60,
+            symbol=symbol, exchange=exchange, timeframe=timeframe,
+        )
 
 
 # ── Consecutive candle pattern scan ────────────────────────────────────────────
@@ -739,7 +776,12 @@ def scan_consecutive_candles(
     try:
         analysis = get_multiple_analysis(screener=screener, interval=timeframe, symbols=symbols)
     except Exception as exc:
-        return {"error": f"Pattern analysis failed: {humanize_upstream_error(exc)}", "exchange": exchange, "timeframe": timeframe}
+        return make_error(
+            ErrorCode.UPSTREAM_ERROR,
+            f"Pattern analysis failed: {humanize_upstream_error(exc)}",
+            retryable=True, retry_after_s=60,
+            exchange=exchange, timeframe=timeframe,
+        )
 
     pattern_coins: list[dict] = []
 

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -158,9 +158,15 @@ def top_losers(exchange: str = "KUCOIN", timeframe: str = "15m", limit: int = 25
 def bollinger_scan(exchange: str = "KUCOIN", timeframe: str = "4h", bbw_threshold: float = 0.04, limit: int = 50) -> list[dict]:
     """Scan for assets with low Bollinger Band Width (squeeze detection). Works with crypto and stocks.
 
+    This scans a whole EXCHANGE for squeezes (canonical name is exactly
+    `bollinger_scan`; there is no "get_bollinger_band_analysis" tool). For
+    the Bollinger read of ONE symbol, call `coin_analysis` instead.
+
+    Example: bollinger_scan(exchange="BINANCE", timeframe="15m", bbw_threshold=0.008)
+
     Args:
         exchange: Exchange — crypto: KUCOIN, BINANCE, BYBIT, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, BURSA, HKEX, SSE, SZSE, TWSE, TPEX
-        timeframe: One of 5m, 15m, 1h, 4h, 1D, 1W, 1M
+        timeframe: One of 5m, 15m, 1h, 4h, 1D, 1W, 1M. Typical squeeze thresholds: 15m→0.008, 1h→0.02, 4h→0.04, 1D→0.12
         bbw_threshold: Maximum BBW value to filter (default 0.04)
         limit: Number of rows to return (max 100)
     """
@@ -206,9 +212,17 @@ def rating_filter(exchange: str = "KUCOIN", timeframe: str = "5m", rating: int =
 def coin_analysis(symbol: str, exchange: str = "KUCOIN", timeframe: str = "15m") -> dict:
     """Get detailed analysis for a specific asset (coin or stock) on specified exchange and timeframe.
 
+    This is the canonical single-symbol technical readout (there is no
+    "get_technical_analysis" or "get_technical_summary" tool — use THIS one).
+    Use `multi_timeframe_analysis` instead when you need trend alignment
+    across several timeframes, and `combined_analysis` when you also want
+    Reddit sentiment + news in the same call.
+
+    Example: coin_analysis(symbol="BTCUSDT", exchange="BINANCE", timeframe="1h")
+
     Args:
-        symbol: Symbol — crypto: "BTCUSDT", "ETHUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX)
-        exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, BURSA, HKEX, SSE, SZSE, TWSE, TPEX
+        symbol: Bare ticker, no exchange prefix — crypto: "BTCUSDT", "ETHUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX)
+        exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, BURSA, HKEX, SSE, SZSE, TWSE, TPEX. If the symbol isn't listed there, the error's `listed_on` field names exchanges that do list it.
         timeframe: Time interval (5m, 15m, 1h, 4h, 1D, 1W, 1M)
 
     Returns:
@@ -523,8 +537,15 @@ def egx_fibonacci_retracement(symbol: str, lookback: str = "52W", timeframe: str
 def multi_timeframe_analysis(symbol: str, exchange: str = "KUCOIN") -> dict:
     """Multi-timeframe alignment analysis (Weekly → Daily → 4H → 1H → 15m).
 
+    Canonical name is exactly `multi_timeframe_analysis` (there is no
+    "get_multi_timeframe_analysis" tool). Use this for cross-timeframe trend
+    alignment on ONE symbol; for a single-timeframe deep dive use
+    `coin_analysis`; for TA + sentiment + news use `combined_analysis`.
+
+    Example: multi_timeframe_analysis(symbol="SOLUSDT", exchange="BINANCE")
+
     Args:
-        symbol: Symbol — crypto: "BTCUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX), "GDX" (AMEX)
+        symbol: Bare ticker, no exchange prefix — crypto: "BTCUSDT"; stocks: "COMI" (EGX), "THYAO" (BIST), "600519" (SSE), "300251" (SZSE), "2330" (TWSE), "3105" (TPEX), "GDX" (AMEX)
         exchange: Exchange — crypto: KUCOIN, BINANCE, MEXC; stocks: EGX, BIST, NASDAQ, NYSE, AMEX, NYSEARCA, PCX, SSE, SZSE, TWSE, TPEX
     """
     exchange = sanitize_exchange(exchange, "KUCOIN")
@@ -562,8 +583,14 @@ def financial_news(symbol: str = None, category: str = "stocks", limit: int = 10
 def combined_analysis(symbol: str, exchange: str = "NASDAQ", timeframe: str = "1D") -> dict:
     """POWER TOOL: TradingView technical analysis + Reddit sentiment + Financial news.
 
+    Use this when you want TA AND sentiment AND news for one symbol in a
+    single call. For indicators only, `coin_analysis` is faster; for
+    cross-timeframe trend alignment use `multi_timeframe_analysis`.
+
+    Example: combined_analysis(symbol="NVDA", exchange="NASDAQ", timeframe="1D")
+
     Args:
-        symbol: Asset symbol ("AAPL", "BTCUSDT", "THYAO", "GDX")
+        symbol: Bare ticker, no exchange prefix ("AAPL", "BTCUSDT", "THYAO", "GDX")
         exchange: Exchange (NASDAQ, NYSE, AMEX, NYSEARCA, PCX, BINANCE, KUCOIN, MEXC, BIST, EGX, TWSE, TPEX)
         timeframe: Analysis timeframe (5m, 15m, 1h, 4h, 1D, 1W)
     """

--- a/tests/unit/services/test_error_envelopes.py
+++ b/tests/unit/services/test_error_envelopes.py
@@ -1,0 +1,115 @@
+"""Error-envelope contract for the hot single-symbol analysis paths.
+
+Asserts the structured-error rules the MCP guidance calls for:
+- SYMBOL_NOT_FOUND: retryable=False + actionable `listed_on` suggestions
+  (a valid-but-unlisted symbol must NOT be retried on the same exchange).
+- UPSTREAM_ERROR (transient TradingView outage): retryable=True with an
+  explicit retry_after_s, so agents wait-and-retry instead of hammering.
+- Message prefixes stay backward-compatible ("No data found for",
+  "Analysis failed:") for anyone substring-matching the old strings.
+"""
+import pytest
+
+import tradingview_mcp.core.services.scanner_service as scanner_service
+import tradingview_mcp.core.services.screener_service as screener_service
+from tradingview_mcp.core.errors import is_error
+
+
+class _NoIndicators:
+    """Truthy analysis row lacking the `indicators` attribute."""
+
+
+def test_analyze_coin_symbol_not_found_envelope(monkeypatch):
+    monkeypatch.setattr(screener_service, "get_multiple_analysis", lambda **kwargs: {})
+    monkeypatch.setattr(screener_service, "_TA_AVAILABLE", True)
+
+    out = screener_service.analyze_coin("HYPEUSDT", "BINANCE", "1h")
+
+    assert is_error(out)
+    err = out["error"]
+    assert err["code"] == "SYMBOL_NOT_FOUND"
+    assert err["retryable"] is False
+    assert err["message"].startswith("No data found for HYPEUSDT on BINANCE")
+    assert "KUCOIN" in err["listed_on"]
+    assert "BINANCE" not in err["listed_on"]
+    assert err["symbol"] == "HYPEUSDT"
+    assert err["timeframe"] == "1h"
+
+
+def test_analyze_coin_unknown_ticker_says_verify_spelling(monkeypatch):
+    monkeypatch.setattr(screener_service, "get_multiple_analysis", lambda **kwargs: {})
+    monkeypatch.setattr(screener_service, "_TA_AVAILABLE", True)
+
+    out = screener_service.analyze_coin("ZZZQQQ123XYZ", "BINANCE", "1h")
+
+    err = out["error"]
+    assert err["code"] == "SYMBOL_NOT_FOUND"
+    assert err["retryable"] is False
+    assert err["listed_on"] == []
+    assert "verify the ticker" in err["message"].lower()
+
+
+def test_analyze_coin_upstream_outage_is_retryable(monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError(
+            "Upstream TradingView scanner returned transient errors on all 3 "
+            "attempts spanning 5s (JSONDecodeError('Expecting value: line 1 "
+            "column 1 (char 0)'))."
+        )
+
+    monkeypatch.setattr(screener_service, "get_multiple_analysis", boom)
+    monkeypatch.setattr(screener_service, "_TA_AVAILABLE", True)
+
+    out = screener_service.analyze_coin("BTCUSDT", "BINANCE", "1h")
+
+    assert is_error(out)
+    err = out["error"]
+    assert err["code"] == "UPSTREAM_ERROR"
+    assert err["retryable"] is True
+    assert err["retry_after_s"] == 60
+    assert err["message"].startswith("Analysis failed:")
+
+
+def test_volume_confirmation_symbol_not_found_envelope(monkeypatch):
+    monkeypatch.setattr(scanner_service, "get_multiple_analysis", lambda **kwargs: {})
+
+    out = scanner_service.volume_confirmation_analyze("HYPEUSDT", "BINANCE", "15m")
+
+    err = out["error"]
+    assert err["code"] == "SYMBOL_NOT_FOUND"
+    assert err["retryable"] is False
+    assert "KUCOIN" in err["listed_on"]
+    assert err["full_symbol"] == "BINANCE:HYPEUSDT"
+
+
+def test_volume_confirmation_no_indicator_row_not_retryable(monkeypatch):
+    row = _NoIndicators()
+    monkeypatch.setattr(
+        scanner_service,
+        "get_multiple_analysis",
+        lambda **kwargs: {"BINANCE:BTCUSDT": row},
+    )
+
+    out = scanner_service.volume_confirmation_analyze("BTCUSDT", "BINANCE", "15m")
+
+    err = out["error"]
+    assert err["code"] == "NO_DATA"
+    assert err["retryable"] is False
+    assert err["message"].startswith("No indicator data for BINANCE:BTCUSDT")
+
+
+def test_volume_confirmation_upstream_outage_is_retryable(monkeypatch):
+    def boom(**kwargs):
+        raise RuntimeError(
+            "Upstream TradingView scanner returned transient errors on all 3 "
+            "attempts spanning 4s."
+        )
+
+    monkeypatch.setattr(scanner_service, "get_multiple_analysis", boom)
+
+    out = scanner_service.volume_confirmation_analyze("BTCUSDT", "BINANCE", "15m")
+
+    err = out["error"]
+    assert err["code"] == "UPSTREAM_ERROR"
+    assert err["retryable"] is True
+    assert err["retry_after_s"] == 60

--- a/tests/unit/test_symbol_suggestions.py
+++ b/tests/unit/test_symbol_suggestions.py
@@ -1,0 +1,45 @@
+"""exchanges_listing_symbol() — local-coinlist exchange suggestions.
+
+These suggestions power the SYMBOL_NOT_FOUND error envelope. Grounded in a
+real production failure: agents retried "HYPEUSDT on BINANCE" 50+ times
+because the old bare-string error offered no alternative and no retryability
+signal. HYPEUSDT ships in the bundled kucoin/mexc/huobi coinlists but not in
+binance's — so the suggestion set below is asserted against the real files.
+"""
+from tradingview_mcp.core.services.coinlist import exchanges_listing_symbol
+
+
+def test_hype_suggests_real_listings_not_binance():
+    listed = exchanges_listing_symbol("HYPEUSDT")
+    assert "KUCOIN" in listed
+    assert "MEXC" in listed
+    assert "BINANCE" not in listed
+
+
+def test_prefixed_symbol_matches_bare_symbol():
+    assert exchanges_listing_symbol("BINANCE:HYPEUSDT") == exchanges_listing_symbol("HYPEUSDT")
+
+
+def test_case_insensitive():
+    assert exchanges_listing_symbol("hypeusdt") == exchanges_listing_symbol("HYPEUSDT")
+
+
+def test_unknown_symbol_returns_empty():
+    assert exchanges_listing_symbol("ZZZQQQ123XYZ") == []
+
+
+def test_blank_symbol_returns_empty():
+    assert exchanges_listing_symbol("") == []
+    assert exchanges_listing_symbol("BINANCE:") == []
+
+
+def test_aggregate_all_list_never_suggested():
+    # all.txt contains every symbol; suggesting "ALL" as an exchange would
+    # steer the model into an invalid `exchange` value.
+    listed = exchanges_listing_symbol("BTCUSDT")
+    assert "ALL" not in listed
+
+
+def test_max_results_cap():
+    listed = exchanges_listing_symbol("BTCUSDT", max_results=2)
+    assert len(listed) <= 2


### PR DESCRIPTION
## Why — grounded in 7d production telemetry
Three real agent-behavior failures, each traced to error/description design:

| Telemetry evidence | Root cause |
|---|---|
| **53 calls** looping on `No data found for HYPEUSDT on binance` | Error was a bare string: no `retryable` signal, no alternative venue |
| **~220 errors** from TradingView's 30-90s empty-body outages, retry hint buried in prose | No machine-readable `retry_after` |
| **16 calls** to nonexistent tools (`get_technical_analysis`, `get_multi_timeframe_analysis`, `get_bollinger_band_analysis`, `get_technical_summary`) | Descriptions didn't anchor canonical names or boundaries between sibling tools |

## What
**1. Structured envelopes with retryability on the hot single-symbol paths** (`analyze_coin`, `volume_confirmation_analyze`, `scan_consecutive_candles` terminal errors):
- Not-found → `SYMBOL_NOT_FOUND`, `retryable: false`, plus **`listed_on` suggestions from the bundled coinlists** — zero network cost. Real case: `HYPEUSDT` on BINANCE now answers *"listed on: HUOBI, KUCOIN, MEXC — retry with one of those as `exchange`"*.
- No-indicator row → `NO_DATA`, `retryable: false`.
- Transient upstream outage → `UPSTREAM_ERROR`, `retryable: true`, `retry_after_s: 60`.
- Message prefixes preserved (`No data found for…`, `Analysis failed:…`) for backward substring compatibility. Uses the existing `core/errors.py` envelope (`make_error`) — this PR widens its adoption exactly as that module's migration notes intended.

**2. Tool-name anchoring + boundaries + examples** on the four hot tools (`coin_analysis`, `multi_timeframe_analysis`, `combined_analysis`, `bollinger_scan`):
- Canonical name stated (e.g. *"there is no get_technical_analysis tool — use THIS one"*),
- Explicit use-this-vs-that boundaries between the three overlapping analysis tools,
- One `Example:` call each; `bollinger_scan` also documents per-timeframe squeeze thresholds (15m→0.008 … 1D→0.12),
- Symbol format clarified ("bare ticker, no exchange prefix").

## Verification
- **154/154 unit tests pass** (141 existing + 13 new).
- New tests assert against the **real coinlist files** (HYPEUSDT → HUOBI/KUCOIN/MEXC, never BINANCE; `all.txt` never suggested as an exchange) and the full envelope contract for both services (codes, retryable flags, retry_after_s, message prefixes).
- Live schema check: server imports clean, 35 tools registered, new description anchors visible in `tools/list` output.

## Non-goals (deliberate)
- No `Literal` types on `exchange`/`timeframe` — `sanitize_*` accepts lenient inputs today; schema-level enums would *create* new validation failures.
- No FastMCP unknown-tool did-you-mean hook — no clean public hook; monkeypatching is version-fragile. Name anchoring in descriptions addresses the observed hallucinations at the source.
- EGX pipeline errors are a separate issue (data-side, tracked separately).