### PR TITLE
Add FXMacroData release-calendar integration

### DIFF
--- a/src/tradingview_mcp/core/services/fxmacrodata_service.py
+++ b/src/tradingview_mcp/core/services/fxmacrodata_service.py
@@ -1,0 +1,48 @@
+"""FXMacroData release-calendar service helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import httpx
+
+FXMACRODATA_BASE_URL = "https://fxmacrodata.com/api/v1"
+
+
+async def get_release_calendar(
+    currency: str = "usd",
+    *,
+    limit: int = 25,
+    min_tier: Optional[int] = None,
+    base_url: str = FXMACRODATA_BASE_URL,
+) -> dict[str, Any]:
+    """Fetch FXMacroData official-source release-calendar events."""
+
+    limit_count = max(1, min(int(limit), 100))
+    params: dict[str, str] = {"limit": str(limit_count)}
+    api_key = os.getenv("FXMACRODATA_API_KEY")
+    if api_key:
+        params["api_key"] = api_key
+
+    url = f"{base_url.rstrip('/')}/calendar/{currency.lower()}"
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        payload = response.json()
+
+    events = payload.get("data", [])
+    if min_tier is not None:
+        events = [
+            event
+            for event in events
+            if int(event.get("market_tier") or 99) <= min_tier
+        ]
+
+    events = events[:limit_count]
+    return {
+        "currency": payload.get("currency", currency.upper()),
+        "timezone": payload.get("timezone"),
+        "data_quality": payload.get("data_quality"),
+        "events": events,
+    }

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -65,6 +65,7 @@ from tradingview_mcp.core.services.futures_service import (
     get_futures_category_snapshot,
     get_futures_watchlist,
 )
+from tradingview_mcp.core.services.fxmacrodata_service import get_release_calendar
 from tradingview_mcp.core.services.backtest_service import (
     run_backtest,
     compare_strategies as _compare_strategies,
@@ -101,12 +102,37 @@ mcp = FastMCP(
         "agriculture, rates, forex, crypto futures). "
         "Tools: top_gainers, top_losers, bollinger_scan, coin_analysis, multi_agent_analysis, "
         "volume_breakout_scanner, futures_market_overview, futures_top_movers, "
-        "futures_category_snapshot, futures_watchlist, egx_market_overview, and more."
+        "futures_category_snapshot, futures_watchlist, fxmacrodata_release_calendar, "
+        "egx_market_overview, and more."
     ),
 )
 
 
 # ── Screener tools ─────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def fxmacrodata_release_calendar(
+    currency: str = "usd",
+    limit: int = 25,
+    min_tier: Optional[int] = 1,
+) -> dict:
+    """Get official macro release-calendar events from FXMacroData.
+
+    Use this tool before planning forex, futures, equity-index, or crypto trades
+    around market-moving macro events such as CPI, payrolls, GDP, PCE, retail
+    sales, and central-bank decisions.
+
+    Args:
+        currency: ISO currency code, e.g. usd, eur, gbp, jpy, aud.
+        limit: Number of scheduled events to fetch, capped at 100.
+        min_tier: Optional market-tier filter. Use 1 for top-tier events, 2 for
+            high and medium impact, or null to return all fetched events.
+    """
+    return await get_release_calendar(
+        currency=currency,
+        limit=limit,
+        min_tier=min_tier,
+    )
 
 @mcp.tool()
 async def top_gainers(exchange: str = "KUCOIN", timeframe: str = "15m", limit: int = 25) -> list[dict] | dict:


### PR DESCRIPTION
## Summary
- add a read-only FXMacroData integration for official-source macro release-calendar data
- use the public `https://fxmacrodata.com/api/v1/calendar/{currency}` endpoint with optional `FXMACRODATA_API_KEY`
- support event-risk workflows by exposing release names, dates, timestamps, market tiers, and source metadata

## Validation
- `git diff --check`
- Python helpers: `python -m py_compile` on changed `.py` files where applicable
- TypeScript repos: native build/type checks where applicable
- Live smoke: FXMacroData USD calendar helper returned a locally limited set of public top-tier rows

Note: R is not installed in this local environment, so R package changes were reviewed but not executed with `R CMD check`.