### PR TITLE
feat: replace RSS + Reddit scraping with licensed Marketaux news/sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ https://github-production-user-asset-6210df.s3.amazonaws.com/67838093/478689497-
 pip install tradingview-mcp-server
 ```
 
+### Optional: news & sentiment (free Marketaux key)
+
+`financial_news` and `market_sentiment` (plus the news/sentiment parts of
+`combined_analysis`) are powered by [Marketaux](https://www.marketaux.com/) —
+licensed market news with per-entity sentiment. Grab a **free API key**
+(100 requests/day; the server caches for 4h and shares one fetch between news
+and sentiment, so the free tier goes a long way) and set:
+
+```bash
+export MARKETAUX_API_TOKEN=your_token_here   # optional
+```
+
+Without a token those two tools return a friendly "not configured" note — all
+other tools work normally.
+
 ### Claude Desktop Config (`claude_desktop_config.json`)
 
 > **Note:** On macOS, GUI apps like Claude Desktop may not have `~/.local/bin` in their PATH. Use the full path to `uvx` to avoid "command not found" errors.

--- a/src/tradingview_mcp/core/services/marketaux_service.py
+++ b/src/tradingview_mcp/core/services/marketaux_service.py
@@ -1,0 +1,297 @@
+"""
+Licensed news + sentiment via the Marketaux API.
+
+Replaces the RSS scrape (news_service.py) and the Reddit scrape
+(sentiment_service.py) with a single licensed source. Both public functions
+keep the exact names and output shapes of the modules they replace, so
+server.py only swaps imports.
+
+Design constraints (free plan: 100 requests/day, 3 articles/request):
+  - ONE underlying fetch per symbol serves BOTH news and sentiment —
+    articles are the news; their entity sentiment scores are the sentiment.
+    combined_analysis therefore costs 1 request, not 2.
+  - 4h TTL cache, stale entries retained: on a daily-timeframe product,
+    4h-old headlines are fine, and stale beats empty when the budget runs out.
+  - Hard daily budget (default 90, env-tunable): once spent, serve stale or a
+    shape-compatible "unavailable" payload — never raise into the tool layer.
+
+Env:
+  MARKETAUX_API_TOKEN   required for live data (no token -> graceful stub)
+  MARKETAUX_DAILY_BUDGET optional, default 90
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+_API_URL = "https://api.marketaux.com/v1/news/all"
+_TIMEOUT = 10
+_TTL_SECONDS = 4 * 3600
+_CACHE_MAX_ENTRIES = 500
+
+# Suffixes used by exchange-style crypto tickers (BTCUSDT -> BTC).
+_QUOTE_SUFFIXES = ("USDT", "USDC", "BUSD", "PERP", "USD")
+_KNOWN_CRYPTO_BASES = {
+    "BTC", "ETH", "SOL", "XRP", "BNB", "ADA", "DOGE", "AVAX", "DOT", "LINK",
+    "TRX", "TON", "PEPE", "AAVE", "HYPE", "TAO", "WLD", "SUI", "NEAR", "LTC",
+}
+
+_lock = threading.Lock()
+_cache: dict[str, tuple[float, list[dict]]] = {}
+_budget = {"day": "", "used": 0}
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _budget_left() -> int:
+    limit = int(os.environ.get("MARKETAUX_DAILY_BUDGET", "90"))
+    if _budget["day"] != _today():
+        _budget["day"] = _today()
+        _budget["used"] = 0
+    return limit - _budget["used"]
+
+
+def _clean_symbol(symbol: str) -> tuple[str, bool]:
+    """BTCUSDT -> ("BTC", True); AAPL -> ("AAPL", False)."""
+    s = (symbol or "").upper().strip()
+    is_crypto = False
+    for suf in _QUOTE_SUFFIXES:
+        if s.endswith(suf) and len(s) > len(suf) + 1:
+            s = s[: -len(suf)]
+            is_crypto = True
+            break
+    if s in _KNOWN_CRYPTO_BASES:
+        is_crypto = True
+    return s, is_crypto
+
+
+def _request(params: dict) -> Optional[list[dict]]:
+    """One live Marketaux call. Returns article list, or None on any failure.
+    Caller is responsible for budget accounting."""
+    token = os.environ.get("MARKETAUX_API_TOKEN", "")
+    if not token:
+        return None
+    q = dict(params)
+    q["api_token"] = token
+    q.setdefault("language", "en")
+    q.setdefault("filter_entities", "true")
+    q.setdefault("limit", "3")
+    url = f"{_API_URL}?{urllib.parse.urlencode(q)}"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "tradingview-mcp"})
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return data.get("data") or []
+    except Exception:
+        return None
+
+
+def _get_articles(symbol: Optional[str], category: str) -> tuple[list[dict], str]:
+    """Cached article fetch. Returns (articles, freshness) where freshness is
+    "live" | "cached" | "stale" | "unavailable"."""
+    if symbol:
+        base, is_crypto = _clean_symbol(symbol)
+        key = f"sym:{base}"
+    else:
+        base, is_crypto = "", category == "crypto"
+        key = f"cat:{category}"
+
+    now = time.time()
+    with _lock:
+        hit = _cache.get(key)
+        if hit and now - hit[0] < _TTL_SECONDS:
+            return hit[1], "cached"
+        if _budget_left() <= 0:
+            return (hit[1], "stale") if hit else ([], "unavailable")
+        _budget["used"] += 1  # reserve before the network call
+
+    if base:
+        # Crypto tickers aren't reliably in Marketaux's symbols index — a text
+        # search on the base finds coin coverage; equities go through symbols=.
+        params = {"search": base} if is_crypto else {"symbols": base}
+    elif category == "crypto":
+        params = {"search": "cryptocurrency OR bitcoin"}
+    else:
+        params = {}  # general market news
+
+    articles = _request(params)
+
+    # Equity-style lookup that came back empty may still be a crypto ticker
+    # we don't know (e.g. a new coin) — one text-search fallback, budget permitting.
+    if base and not is_crypto and articles == []:
+        with _lock:
+            can_retry = _budget_left() > 0
+            if can_retry:
+                _budget["used"] += 1
+        if can_retry:
+            articles = _request({"search": base})
+
+    with _lock:
+        if articles is None:
+            hit = _cache.get(key)
+            return (hit[1], "stale") if hit else ([], "unavailable")
+        _cache[key] = (now, articles)
+        if len(_cache) > _CACHE_MAX_ENTRIES:
+            oldest = min(_cache, key=lambda k: _cache[k][0])
+            _cache.pop(oldest, None)
+        return articles, "live"
+
+
+def _clean_text(text: str) -> str:
+    import re
+    text = re.sub(r"<[^>]+>", "", text or "")
+    for entity, char in (("&amp;", "&"), ("&lt;", "<"), ("&gt;", ">"), ("&nbsp;", " ")):
+        text = text.replace(entity, char)
+    return text.strip()
+
+
+# Keyword fallback for articles Marketaux returns WITHOUT entity scores (its
+# text-search path — most crypto coverage — attaches no entities). Same scorer
+# the old Reddit service used, applied to licensed headline/description text.
+_BULLISH_KEYWORDS = [
+    "buy", "bull", "moon", "pump", "long", "call", "up", "gain",
+    "strong", "breakout", "bullish", "rally", "surge", "upside",
+    "accumulate", "undervalued", "support", "bottom", "recovery",
+]
+_BEARISH_KEYWORDS = [
+    "sell", "bear", "dump", "short", "put", "down", "loss", "weak",
+    "crash", "drop", "bearish", "tank", "decline", "downside",
+    "overvalued", "resistance", "top", "overbought", "bubble",
+]
+
+
+def _keyword_score(text: str) -> float:
+    t = (text or "").lower()
+    bull = sum(1 for w in _BULLISH_KEYWORDS if w in t)
+    bear = sum(1 for w in _BEARISH_KEYWORDS if w in t)
+    total = bull + bear
+    if total == 0:
+        return 0.0
+    return (bull - bear) / total
+
+
+def _label(score: float) -> str:
+    if score > 0.2:
+        return "Strongly Bullish"
+    elif score > 0.05:
+        return "Bullish"
+    elif score < -0.2:
+        return "Strongly Bearish"
+    elif score < -0.05:
+        return "Bearish"
+    return "Neutral"
+
+
+# ─── Public API (same names/shapes as the modules this replaces) ─────────────
+
+def fetch_news_summary(
+    symbol: Optional[str] = None,
+    category: str = "stocks",
+    limit: int = 10,
+) -> dict:
+    """Licensed financial news via Marketaux. Same output shape as the old
+    RSS-based fetch_news_summary."""
+    if not os.environ.get("MARKETAUX_API_TOKEN"):
+        return {
+            "symbol": symbol, "category": category, "count": 0, "items": [],
+            "provider": "marketaux",
+            "error": "MARKETAUX_API_TOKEN not configured",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    articles, freshness = _get_articles(symbol, category)
+    items = [{
+        "title": a.get("title", ""),
+        "url": a.get("url", ""),
+        "published": a.get("published_at", ""),
+        "summary": _clean_text(a.get("description") or a.get("snippet") or "")[:300],
+        "source": a.get("source", "Marketaux"),
+    } for a in articles[:limit]]
+    out = {
+        "symbol": symbol,
+        "category": category,
+        "count": len(items),
+        "items": items,
+        "provider": "marketaux",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if freshness in ("stale", "unavailable"):
+        out["note"] = f"news {freshness}: daily news budget exhausted or provider unreachable"
+    return out
+
+
+def analyze_sentiment(
+    symbol: str,
+    category: str = "all",
+    limit: int = 20,
+) -> dict:
+    """News-based sentiment via Marketaux entity sentiment scores. Same output
+    shape as the old Reddit-based analyze_sentiment (top_posts now carries
+    news articles instead of Reddit posts)."""
+    base, _ = _clean_symbol(symbol)
+    if not os.environ.get("MARKETAUX_API_TOKEN"):
+        return {
+            "symbol": (symbol or "").upper(), "sentiment_score": 0.0,
+            "sentiment_label": "Unavailable", "posts_analyzed": 0,
+            "bullish_count": 0, "bearish_count": 0, "neutral_count": 0,
+            "top_posts": [], "sources": ["Marketaux news"],
+            "provider": "marketaux",
+            "error": "MARKETAUX_API_TOKEN not configured",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    articles, freshness = _get_articles(symbol, category)
+
+    scores: list[float] = []
+    top: list[dict] = []
+    for a in articles:
+        ent_scores = [
+            e.get("sentiment_score")
+            for e in (a.get("entities") or [])
+            if isinstance(e.get("sentiment_score"), (int, float))
+            and (e.get("symbol", "").upper().startswith(base) if base else True)
+        ]
+        if not ent_scores:  # fall back to any scored entity on the article
+            ent_scores = [
+                e.get("sentiment_score")
+                for e in (a.get("entities") or [])
+                if isinstance(e.get("sentiment_score"), (int, float))
+            ]
+        if ent_scores:
+            art_score = sum(ent_scores) / len(ent_scores)
+        else:
+            # No entity scores at all (Marketaux's text-search path) —
+            # keyword-score the licensed headline/description text instead.
+            art_score = _keyword_score(f"{a.get('title', '')} {a.get('description', '')}")
+        scores.append(art_score)
+        top.append({
+            "title": (a.get("title") or "")[:120],
+            "url": a.get("url", ""),
+            "sentiment": "bullish" if art_score > 0.05 else "bearish" if art_score < -0.05 else "neutral",
+            "source": a.get("source", "Marketaux"),
+            "published": a.get("published_at", ""),
+        })
+
+    avg = sum(scores) / len(scores) if scores else 0.0
+    out = {
+        "symbol": (symbol or "").upper(),
+        "sentiment_score": round(avg, 3),
+        "sentiment_label": _label(avg),
+        "posts_analyzed": len(scores),
+        "bullish_count": sum(1 for s in scores if s > 0.05),
+        "bearish_count": sum(1 for s in scores if s < -0.05),
+        "neutral_count": sum(1 for s in scores if -0.05 <= s <= 0.05),
+        "top_posts": top[:5],
+        "sources": ["Marketaux news"],
+        "provider": "marketaux",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if freshness in ("stale", "unavailable"):
+        out["note"] = f"sentiment {freshness}: daily news budget exhausted or provider unreachable"
+    return out

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -43,8 +43,10 @@ from tradingview_mcp.core.services.egx_service import (
     generate_egx_trade_plan,
     analyze_egx_fibonacci,
 )
-from tradingview_mcp.core.services.sentiment_service import analyze_sentiment
-from tradingview_mcp.core.services.news_service import fetch_news_summary
+from tradingview_mcp.core.services.marketaux_service import (
+    analyze_sentiment,
+    fetch_news_summary,
+)
 from tradingview_mcp.core.services.yahoo_finance_service import (
     get_price,
     get_price_async,
@@ -226,7 +228,7 @@ def coin_analysis(symbol: str, exchange: str = "KUCOIN", timeframe: str = "15m")
     "get_technical_analysis" or "get_technical_summary" tool — use THIS one).
     Use `multi_timeframe_analysis` instead when you need trend alignment
     across several timeframes, and `combined_analysis` when you also want
-    Reddit sentiment + news in the same call.
+    news sentiment + headlines in the same call.
 
     Example: coin_analysis(symbol="BTCUSDT", exchange="BINANCE", timeframe="1h")
 
@@ -576,34 +578,33 @@ async def multi_timeframe_analysis(symbol: str, exchange: str = "KUCOIN") -> dic
 
 @mcp.tool()
 def market_sentiment(symbol: str, category: str = "all", limit: int = 20) -> dict:
-    """Real-time Reddit sentiment analysis for stocks and crypto.
+    """News sentiment for stocks and crypto (licensed Marketaux entity sentiment).
 
     Args:
         symbol: Asset symbol ("AAPL", "BTC", "ETH", "TSLA")
-        category: Subreddit group to search ("crypto", "stocks", "all")
-        limit: Number of posts to analyse
+        category: News group to search ("crypto", "stocks", "all")
+        limit: Max articles to analyse
     """
     return analyze_sentiment(symbol, category, limit)
 
 
 @mcp.tool()
 async def financial_news(symbol: str = None, category: str = "stocks", limit: int = 10) -> dict:
-    """Real-time financial news from RSS feeds (Reuters, CoinDesk, etc.)
+    """Real-time financial news via Marketaux (licensed).
 
     Args:
         symbol: Optional symbol filter ("AAPL", "BTC"). None = all news.
-        category: Feed category ("crypto", "stocks", "all")
+        category: News category ("crypto", "stocks", "all")
         limit: Max number of news items
     """
-    # feedparser.parse() is sync — offload so multiple parallel news
-    # requests (or a news call interleaved with other tools) don't block
-    # the event loop.
+    # The Marketaux fetch is sync (urllib) — offload so parallel news
+    # requests don't block the event loop.
     return await asyncio.to_thread(fetch_news_summary, symbol, category, limit)
 
 
 @mcp.tool()
 async def combined_analysis(symbol: str, exchange: str = "NASDAQ", timeframe: str = "1D") -> dict:
-    """POWER TOOL: TradingView technical analysis + Reddit sentiment + Financial news.
+    """POWER TOOL: TradingView technical analysis + news sentiment + financial news.
 
     Use this when you want TA AND sentiment AND news for one symbol in a
     single call. For indicators only, `coin_analysis` is faster; for
@@ -621,7 +622,7 @@ async def combined_analysis(symbol: str, exchange: str = "NASDAQ", timeframe: st
     cat = "crypto" if exchange_clean.upper() in ["BINANCE", "KUCOIN", "BYBIT", "MEXC"] else "stocks"
 
     # The three sub-calls hit independent upstreams (TradingView TA,
-    # Reddit, RSS feeds) so fan them out in parallel. Pre-P4 this was
+    # Marketaux news/sentiment) so fan them out in parallel. Pre-P4 this was
     # ~3x sequential wall-clock; now bounded by the slowest single call.
     # The TA throttle (threading.Semaphore in screener_provider) still
     # caps in-flight TV calls correctly because asyncio.to_thread runs
@@ -652,8 +653,8 @@ async def combined_analysis(symbol: str, exchange: str = "NASDAQ", timeframe: st
             "recommendation": (
                 f"Technical {tech_signal} "
                 f"{'confirmed by' if signals_agree else 'conflicts with'} "
-                f"{sentiment.get('sentiment_label', 'Neutral')} Reddit sentiment "
-                f"({sentiment.get('posts_analyzed', 0)} posts analyzed)"
+                f"{sentiment.get('sentiment_label', 'Neutral')} news sentiment "
+                f"({sentiment.get('posts_analyzed', 0)} articles analyzed)"
             ),
         },
     }


### PR DESCRIPTION
## Why
`financial_news` scraped RSS feeds (Yahoo/MarketWatch/CNBC) and `market_sentiment` scraped Reddit's JSON API — both redistribute data whose terms forbid commercial reuse. This swaps both onto **Marketaux**, a licensed news API, keeping tool signatures and output shapes identical.

## Design (free plan: 100 req/day, 3 articles/req)
- **One cached fetch per symbol serves both news AND sentiment** (articles = news; entity sentiment = sentiment) → `combined_analysis` costs 1 provider request, not 2.
- **4h TTL cache + hard daily budget** (`MARKETAUX_DAILY_BUDGET`, default 90) with stale-serve fallback. Worst observed day would be ~429 uncached requests — the cache/budget layer is the core of the design.
- Marketaux's text-search path (most crypto coverage) attaches no entity scores → those articles are **keyword-scored on licensed headline text** (same scorer the Reddit version used). Verified live: BTCUSDT sentiment works.
- No token → shape-compatible "not configured" payloads (tools never raise).

## Verified
- Live smoke with a real token: AAPL news ✓, AAPL entity sentiment ("Strongly Bullish") ✓, BTCUSDT crypto path ✓, shared cache spends 0 extra budget ✓.
- `py_compile` clean; no Reddit/RSS references left in server.py.
- Note: the default pytest suite currently INTERNALERRORs **on main too** (a collection-time script asserts sync tool returns post-#49 async conversion) — pre-existing, unrelated; this PR doesn't touch it.

## Rollout
Needs `MARKETAUX_API_TOKEN` in the hosted stack's env **before** pulling the new image (otherwise news/sentiment return "not configured"). Old `news_service.py`/`sentiment_service.py` stay on disk unimported; removal is a follow-up after soak.