### PR TITLE
fix(backtest): Donchian never trades, walk-forward scores overfitting backwards, + 4 more

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -33,7 +33,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # No image reaches GHCR from a commit whose tests fail.
+  test:
+    uses: ./.github/workflows/test.yml
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+# Run the hermetic unit suite.
+#
+# Callable from other workflows (see publish-image.yml) so that no image is
+# ever pushed from a commit whose tests do not pass.
+#
+# The real-network stress suite is excluded by the `-m "not stress"` default in
+# pyproject.toml and is not run here.
+
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:      # publish-image.yml calls this on pushes to main
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors requires-python = ">=3.10,<3.14" in pyproject.toml.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install the package and test deps
+        # Editable install, not PYTHONPATH: a bare `pytest` cannot import
+        # tradingview_mcp otherwise, and the suite would appear to pass by
+        # collecting nothing.
+        run: uv pip install --system -e . pytest pytest-asyncio
+
+      - name: Verify the suite actually collected
+        # A misconfigured import makes pytest collect nothing and exit green.
+        run: |
+          python -m pytest tests/unit --collect-only -q | tee /tmp/collected.txt | tail -1
+          grep -qE '[0-9]+ tests? collected' /tmp/collected.txt || {
+            echo "::error::pytest collected no tests — a green run here would be meaningless"
+            exit 1
+          }
+
+      - name: Run unit tests
+        run: python -m pytest tests/unit -q

--- a/src/tradingview_mcp/core/services/backtest_service.py
+++ b/src/tradingview_mcp/core/services/backtest_service.py
@@ -448,7 +448,8 @@ def _calc_metrics(
         "total_trades": 0, "win_rate_pct": 0, "winning_trades": 0, "losing_trades": 0,
         "total_return_pct": 0, "final_capital": initial_capital,
         "avg_gain_pct": 0, "avg_loss_pct": 0, "max_drawdown_pct": 0,
-        "profit_factor": 0, "sharpe_ratio": 0, "calmar_ratio": 0,
+        "profit_factor": 0, "no_losing_trades": False,
+        "sharpe_ratio": 0, "calmar_ratio": 0,
         "expectancy_pct": 0, "best_trade": None, "worst_trade": None,
     }
     if not trades:

--- a/src/tradingview_mcp/core/services/backtest_service.py
+++ b/src/tradingview_mcp/core/services/backtest_service.py
@@ -189,13 +189,17 @@ def _run_donchian(candles, period=20, **_):
     dc     = calc_donchian(highs, lows, period)
     trades, position = [], None
     for i in range(1, len(candles)):
-        if dc["upper"][i] is None:
+        # Break the *previous* bar's channel. calc_donchian's window for bar i
+        # includes bar i itself, so comparing bar i (or i-1) against its own
+        # channel can never be a breakout: a value is never strictly greater
+        # than a max that contains it.
+        upper, lower = dc["upper"][i - 1], dc["lower"][i - 1]
+        if upper is None or lower is None:
             continue
         price, date = candles[i]["close"], candles[i]["date"]
-        prev_high   = highs[i - 1]
-        if position is None and dc["upper"][i - 1] is not None and prev_high > dc["upper"][i - 1]:
+        if position is None and price > upper:
             position = {"entry_date": date, "entry_price": price, "strategy": "donchian"}
-        elif position is not None and dc["lower"][i] is not None and price < dc["lower"][i]:
+        elif position is not None and price < lower:
             trades.append({**position, "exit_date": date, "exit_price": price})
             position = None
     return trades
@@ -356,7 +360,90 @@ def _build_equity_curve(trades: list[dict], initial_capital: float) -> list[dict
 
 # ─── Metrics ──────────────────────────────────────────────────────────────────
 
-def _calc_metrics(trades: list[dict], initial_capital: float, interval: str = "1d") -> dict:
+_DATE_FORMATS = ("%Y-%m-%d %H:%M", "%Y-%m-%d")
+
+
+def _parse_bar_date(value: str) -> Optional[datetime]:
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+def _trades_per_year(trades: list[dict], interval: str) -> float:
+    """Observations-per-year factor for annualising *per-trade* returns.
+
+    ``_calc_metrics`` builds one return per trade, not one per bar. Annualising
+    those by the bar count (252 for daily) assumes a trade every bar and
+    inflates Sharpe by ``sqrt(252 / actual_trades_per_year)`` — roughly 16x for
+    a ten-trade year. Derive the real frequency from the trade dates instead.
+
+    Falls back to the bar-count factor when dates are unusable, and caps at it
+    besides: a strategy cannot trade more often than the data has bars.
+    """
+    bars_per_year = float(_ANNUALIZATION.get(interval, 252))
+
+    first = _parse_bar_date(trades[0]["entry_date"])
+    last  = _parse_bar_date(trades[-1]["exit_date"])
+    if first is None or last is None:
+        return bars_per_year
+
+    span_years = (last - first).total_seconds() / (365.25 * 24 * 3600)
+    if span_years <= 0:
+        return bars_per_year
+
+    return min(len(trades) / span_years, bars_per_year)
+
+
+def _max_drawdown_pct(
+    trades: list[dict],
+    initial_capital: float,
+    candles: Optional[list[dict]] = None,
+) -> float:
+    """Largest peak-to-trough equity decline, in percent.
+
+    Given *candles*, the open position is marked to market on every bar it is
+    held, so a drawdown that opens and closes inside a single trade is seen.
+    Without them the curve is sampled only at trade exits, which understates
+    the true decline — and so inflates Calmar, which divides by it.
+
+    Marking uses each bar's close, not its low, so this is a close-to-close
+    figure: still a lower bound on intraday pain, but a far tighter one.
+    """
+    equity = peak = float(initial_capital)
+    max_dd = 0.0
+
+    def observe(value: float) -> None:
+        nonlocal peak, max_dd
+        peak = max(peak, value)
+        if peak > 0:
+            max_dd = max(max_dd, (peak - value) / peak * 100)
+
+    bar_index = {c["date"]: i for i, c in enumerate(candles)} if candles else {}
+
+    for trade in trades:
+        start = bar_index.get(trade["entry_date"])
+        end   = bar_index.get(trade["exit_date"])
+        entry = trade.get("entry_price") or 0
+
+        if start is not None and end is not None and end >= start and entry > 0:
+            for bar in candles[start:end + 1]:
+                observe(equity * (bar["close"] / entry))
+
+        equity *= (1 + trade["return_pct"] / 100)
+        observe(equity)
+
+    return max_dd
+
+
+def _calc_metrics(
+    trades: list[dict],
+    initial_capital: float,
+    interval: str = "1d",
+    candles: Optional[list[dict]] = None,
+) -> dict:
     empty = {
         "total_trades": 0, "win_rate_pct": 0, "winning_trades": 0, "losing_trades": 0,
         "total_return_pct": 0, "final_capital": initial_capital,
@@ -371,30 +458,33 @@ def _calc_metrics(trades: list[dict], initial_capital: float, interval: str = "1
     losers  = [t for t in trades if t["return_pct"] <= 0]
 
     capital = initial_capital
-    peak    = capital
-    max_dd  = 0.0
     returns = []
     for t in trades:
         r = t["return_pct"] / 100
         capital *= (1 + r)
         returns.append(r)
-        peak   = max(peak, capital)
-        max_dd = max(max_dd, (peak - capital) / peak * 100)
+
+    max_dd = _max_drawdown_pct(trades, initial_capital, candles)
 
     total_return  = (capital - initial_capital) / initial_capital * 100
     avg_gain      = sum(t["return_pct"] for t in winners) / len(winners) if winners else 0
     avg_loss      = sum(t["return_pct"] for t in losers)  / len(losers)  if losers  else 0
     gp            = sum(t["return_pct"] for t in winners)
     gl            = abs(sum(t["return_pct"] for t in losers))
-    profit_factor = round(gp / gl, 2) if gl > 0 else float("inf")
 
-    ann  = _ANNUALIZATION.get(interval, 252)
+    # No losing trades means the ratio is undefined, not infinite. float("inf")
+    # serialises as the bare token `Infinity`, which is not valid JSON — a
+    # strict client fails to decode the whole tool response, not just this key.
+    profit_factor = round(gp / gl, 2) if gl > 0 else None
+
+    # Per-trade returns annualise by trade frequency, not by bar count.
+    factor = _trades_per_year(trades, interval)
     sharpe = 0.0
-    if len(returns) > 1:
+    if len(returns) > 1 and factor > 0:
         mean_r = statistics.mean(returns)
         std_r  = statistics.stdev(returns)
         if std_r > 0:
-            sharpe = round((mean_r - 0.04 / ann) / std_r * math.sqrt(ann), 2)
+            sharpe = round((mean_r - 0.04 / factor) / std_r * math.sqrt(factor), 2)
 
     calmar = round(total_return / max_dd, 2) if max_dd > 0 else 0.0
 
@@ -414,6 +504,7 @@ def _calc_metrics(trades: list[dict], initial_capital: float, interval: str = "1
         "avg_loss_pct":     round(avg_loss, 2),
         "max_drawdown_pct": round(-max_dd, 2),
         "profit_factor":    profit_factor,
+        "no_losing_trades": profit_factor is None,
         "sharpe_ratio":     sharpe,
         "calmar_ratio":     calmar,
         "expectancy_pct":   expectancy,
@@ -507,7 +598,7 @@ def run_backtest(
 
     raw_trades = _STRATEGY_MAP[strategy](candles)
     trades     = _apply_costs(raw_trades, commission_pct, slippage_pct)
-    metrics    = _calc_metrics(trades, initial_capital, interval)
+    metrics    = _calc_metrics(trades, initial_capital, interval, candles)
     bnh        = _buy_and_hold_return(candles)
 
     result = {
@@ -575,7 +666,7 @@ def compare_strategies(
     for strat, fn in _STRATEGY_MAP.items():
         raw    = fn(candles)
         trades = _apply_costs(raw, commission_pct, slippage_pct)
-        m      = _calc_metrics(trades, initial_capital, interval)
+        m      = _calc_metrics(trades, initial_capital, interval, candles)
         results.append({
             "strategy":         strat,
             "strategy_label":   _STRATEGY_LABELS[strat],
@@ -622,6 +713,33 @@ def compare_strategies(
 
 
 # ─── Public API: walk_forward_backtest ────────────────────────────────────────
+
+def _fold_robustness(train_m: dict, test_m: dict) -> float:
+    """Score one walk-forward fold: how well in-sample performance held up.
+
+    ``1.0`` means out-of-sample matched in-sample; below ``0.2`` the caller
+    reports OVERFITTED. Capped at ``2.0`` so one lucky fold cannot carry the
+    average, and floored at ``-1.0`` so one blow-up cannot sink it.
+
+    A fold earns ``0.0`` — not a ratio — whenever there is nothing to validate:
+
+    * Either window produced no trades. A strategy that never fires has not
+      demonstrated robustness, and ``0 / 0`` is not evidence of consistency.
+    * The strategy lost money in-sample. There is no edge to generalise, so
+      out-of-sample behaviour cannot confirm one. Dividing two negative returns
+      would yield a *positive* ratio here, scoring a strategy that lost more
+      out-of-sample as maximally robust — the exact inversion this function
+      exists to prevent.
+    """
+    if train_m["total_trades"] == 0 or test_m["total_trades"] == 0:
+        return 0.0
+
+    train_return = train_m["total_return_pct"]
+    if train_return <= 0:
+        return 0.0
+
+    return round(max(min(test_m["total_return_pct"] / train_return, 2.0), -1.0), 2)
+
 
 def walk_forward_backtest(
     symbol: str,
@@ -700,20 +818,12 @@ def walk_forward_backtest(
 
         train_t = _apply_costs(fn(train_c), commission_pct, slippage_pct)
         test_t  = _apply_costs(fn(test_c),  commission_pct, slippage_pct)
-        train_m = _calc_metrics(train_t, initial_capital, interval)
-        test_m  = _calc_metrics(test_t,  initial_capital, interval)
+        train_m = _calc_metrics(train_t, initial_capital, interval, train_c)
+        test_m  = _calc_metrics(test_t,  initial_capital, interval, test_c)
 
         all_test_trades.extend(test_t)
 
-        tr, te = train_m["total_return_pct"], test_m["total_return_pct"]
-        if tr == 0:
-            fold_rob = 1.0 if te == 0 else 0.0
-        elif tr < 0 and te < 0:
-            fold_rob = round(min(te / tr, 2.0), 2)
-        elif tr < 0:
-            fold_rob = 0.0
-        else:
-            fold_rob = round(max(min(te / tr, 2.0), -1.0), 2)
+        fold_rob = _fold_robustness(train_m, test_m)
 
         folds.append({
             "fold":                  fold_i + 1,
@@ -738,7 +848,7 @@ def walk_forward_backtest(
     avg_train  = round(statistics.mean(f["train_return_pct"] for f in folds), 2)
     avg_test   = round(statistics.mean(f["test_return_pct"]  for f in folds), 2)
     avg_robust = round(statistics.mean(f["fold_robustness_score"] for f in folds), 2)
-    oos_m      = _calc_metrics(all_test_trades, initial_capital, interval)
+    oos_m      = _calc_metrics(all_test_trades, initial_capital, interval, candles)
 
     if avg_robust >= 0.8:
         verdict = "ROBUST — strategy performs consistently in-sample and out-of-sample"

--- a/src/tradingview_mcp/core/services/scanner_service.py
+++ b/src/tradingview_mcp/core/services/scanner_service.py
@@ -145,11 +145,13 @@ def volume_breakout_scan(
 
                 price_change = ((close - open_price) / open_price) * 100 if open_price > 0 else 0
 
-                if sma20_volume and sma20_volume > 0:
-                    volume_ratio = volume / sma20_volume
-                else:
-                    avg_estimate = volume / 2
-                    volume_ratio = volume / avg_estimate if avg_estimate > 0 else 1
+                # Without an average to compare against there is no ratio. The
+                # old fallback estimated the average as volume/2, which made the
+                # ratio exactly 2.0 — passing the default 2.0 threshold for every
+                # symbol whose average volume upstream happened to omit.
+                if not sma20_volume or sma20_volume <= 0:
+                    continue
+                volume_ratio = volume / sma20_volume
 
                 if abs(price_change) >= price_change_min and volume_ratio >= volume_multiplier:
                     rsi = ind.get("RSI", 50)

--- a/tests/unit/services/_synthetic.py
+++ b/tests/unit/services/_synthetic.py
@@ -1,0 +1,61 @@
+"""Deterministic synthetic OHLCV series for strategy tests.
+
+No randomness and no network: every strategy test must fail for exactly one
+reason — the strategy logic changed — never because a seed moved.
+"""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+
+def make_candles(closes: list[float], *, start: str = "2024-01-01") -> list[dict]:
+    """Wrap a close series into candles with a plausible high/low envelope."""
+    day = datetime.strptime(start, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    candles = []
+    for i, close in enumerate(closes):
+        prev = closes[i - 1] if i else close
+        candles.append({
+            "date":   (day + timedelta(days=i)).strftime("%Y-%m-%d"),
+            "open":   round(prev, 4),
+            "high":   round(max(prev, close) * 1.005, 4),
+            "low":    round(min(prev, close) * 0.995, 4),
+            "close":  round(close, 4),
+            "volume": 1_000_000,
+        })
+    return candles
+
+
+def regime_closes(n: int = 420) -> list[float]:
+    """A series with every regime the nine strategies need to fire.
+
+    Long enough to clear the 220-bar SMA200 warmup, and shaped so that each
+    strategy sees at least one entry *and* one exit: a slow uptrend carries the
+    trend followers, a superimposed oscillation carries the mean-reverters, and
+    two sharp drawdowns force exits and channel breakdowns.
+    """
+    closes = []
+    for i in range(n):
+        trend = 100.0 * (1.0 + 0.0035 * i)          # steady drift up
+        wave  = 9.0 * math.sin(i / 7.0)             # mean-reversion fodder
+        swell = 4.0 * math.sin(i / 41.0)            # slower breathing
+        shock = 0.0
+        if 250 <= i < 280:                          # sharp drawdown
+            shock = -38.0 * math.sin((i - 250) / 30.0 * math.pi)
+        if 360 <= i < 385:                          # second, shallower one
+            shock = -22.0 * math.sin((i - 360) / 25.0 * math.pi)
+        closes.append(trend + wave + swell + shock)
+    return closes
+
+
+def breakout_closes() -> list[float]:
+    """Flat channel, clean upside breakout, then a clean breakdown.
+
+    Purpose-built for Donchian: bars 0-29 define a tight channel, bars 30-44
+    break decisively above it, bars 45-69 collapse decisively below it.
+    """
+    return (
+        [100.0 + (i % 3) for i in range(30)]        # chop between 100 and 102
+        + [104.0 + 2.0 * i for i in range(15)]      # breakout up to 132
+        + [130.0 - 3.0 * i for i in range(25)]      # breakdown through the floor
+    )

--- a/tests/unit/services/test_metrics.py
+++ b/tests/unit/services/test_metrics.py
@@ -1,0 +1,195 @@
+"""Correctness tests for backtest metrics and walk-forward fold scoring."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tradingview_mcp.core.services.backtest_service import (
+    _calc_metrics,
+    _fold_robustness,
+    _max_drawdown_pct,
+    _trades_per_year,
+)
+
+from ._synthetic import make_candles
+
+
+def trade(entry_date, exit_date, entry, exit_, return_pct):
+    return {
+        "entry_date": entry_date, "exit_date": exit_date,
+        "entry_price": entry, "exit_price": exit_,
+        "return_pct": return_pct, "strategy": "test",
+    }
+
+
+# ─── Walk-forward robustness: the F-02 regression ─────────────────────────────
+
+def metrics(total_return_pct, total_trades=5):
+    return {"total_return_pct": total_return_pct, "total_trades": total_trades}
+
+
+def test_losing_worse_out_of_sample_never_outscores_losing_less():
+    """The inversion that scored a 5x-worse strategy as maximally robust.
+
+    Dividing two negative returns yields a positive ratio, so `te/tr` for
+    (-10%, -50%) was 5.0, capped to the maximum 2.0 → verdict ROBUST. Meanwhile
+    (-10%, -2%), which *improved* out-of-sample, scored 0.2 → OVERFITTED.
+    """
+    much_worse = _fold_robustness(metrics(-10.0), metrics(-50.0))
+    slightly_better = _fold_robustness(metrics(-10.0), metrics(-2.0))
+
+    assert much_worse <= slightly_better
+    assert much_worse == 0.0, "a strategy that lost in-sample has no edge to validate"
+
+
+@pytest.mark.parametrize("train_return", [-50.0, -10.0, -0.01, 0.0])
+def test_no_edge_in_sample_scores_zero(train_return):
+    assert _fold_robustness(metrics(train_return), metrics(25.0)) == 0.0
+
+
+def test_a_fold_that_never_traded_is_not_robust():
+    """`0/0` is not evidence of consistency.
+
+    Before the donchian fix this was the *only* branch donchian ever hit, and it
+    returned 1.0 — a perfect robustness score for a strategy that never traded.
+    """
+    assert _fold_robustness(metrics(0.0, total_trades=0), metrics(0.0, total_trades=0)) == 0.0
+    assert _fold_robustness(metrics(20.0, total_trades=5), metrics(0.0, total_trades=0)) == 0.0
+
+
+def test_holding_up_out_of_sample_scores_near_one():
+    assert _fold_robustness(metrics(20.0), metrics(18.0)) == 0.9
+
+
+def test_robustness_is_clamped_both_ways():
+    assert _fold_robustness(metrics(10.0), metrics(500.0)) == 2.0    # one lucky fold
+    assert _fold_robustness(metrics(10.0), metrics(-500.0)) == -1.0  # one blow-up
+
+
+# ─── profit_factor: the F-05 regression ───────────────────────────────────────
+
+def test_no_losing_trades_yields_json_safe_profit_factor():
+    """float("inf") serialises as the bare token `Infinity` — not valid JSON.
+
+    A strict client fails to decode the entire tool response, not just this key.
+    """
+    winners_only = [
+        trade("2024-01-01", "2024-01-05", 100, 110, 10.0),
+        trade("2024-02-01", "2024-02-05", 100, 105, 5.0),
+    ]
+    m = _calc_metrics(winners_only, 10_000, "1d")
+
+    assert m["profit_factor"] is None
+    assert m["no_losing_trades"] is True
+
+    encoded = json.dumps(m)
+    assert "Infinity" not in encoded
+    json.loads(encoded, parse_constant=_reject)  # strict: no Infinity/NaN allowed
+
+
+def _reject(token):
+    raise AssertionError(f"non-JSON constant emitted: {token}")
+
+
+def test_profit_factor_is_a_ratio_when_there_are_losers():
+    trades = [
+        trade("2024-01-01", "2024-01-05", 100, 120, 20.0),
+        trade("2024-02-01", "2024-02-05", 100, 90, -10.0),
+    ]
+    m = _calc_metrics(trades, 10_000, "1d")
+    assert m["profit_factor"] == 2.0
+    assert m["no_losing_trades"] is False
+
+
+# ─── Sharpe annualisation: the F-03 regression ────────────────────────────────
+
+def test_annualisation_follows_trade_frequency_not_bar_count():
+    """Two trades spread over two years is not 252 observations a year."""
+    sparse = [
+        trade("2024-01-01", "2024-01-10", 100, 110, 10.0),
+        trade("2025-06-01", "2025-12-20", 100, 105, 5.0),
+    ]
+    factor = _trades_per_year(sparse, "1d")
+    assert 0.8 < factor < 1.3, f"expected ~1 trade/year, got {factor}"
+
+
+def test_annualisation_never_exceeds_the_bar_count():
+    """A strategy cannot trade more often than the data has bars."""
+    burst = [
+        trade("2024-01-01", "2024-01-01", 100, 101, 1.0),
+        trade("2024-01-02", "2024-01-02", 100, 101, 1.0),
+    ]
+    assert _trades_per_year(burst, "1d") <= 252
+
+
+def test_sparse_trading_is_not_awarded_a_dense_trading_sharpe():
+    """The old code scaled per-trade returns by sqrt(252) regardless.
+
+    Identical returns spread over two years must not earn the same Sharpe as
+    the same returns taken daily.
+    """
+    returns = [8.0, -3.0, 6.0, -2.0]
+    sparse = [
+        trade(f"202{i}-01-01", f"202{i}-03-01", 100, 100 + r, r)
+        for i, r in enumerate(returns)
+    ]
+    dense = [
+        trade(f"2024-01-{i+1:02d}", f"2024-01-{i+2:02d}", 100, 100 + r, r)
+        for i, r in enumerate(returns)
+    ]
+
+    sparse_sharpe = _calc_metrics(sparse, 10_000, "1d")["sharpe_ratio"]
+    dense_sharpe = _calc_metrics(dense, 10_000, "1d")["sharpe_ratio"]
+
+    assert abs(sparse_sharpe) < abs(dense_sharpe), (
+        "annualisation must reward trade frequency, not ignore it"
+    )
+
+
+# ─── Drawdown sampling: the F-04 regression ───────────────────────────────────
+
+def test_intra_trade_drawdown_is_captured_when_candles_are_supplied():
+    """Sampling equity only at exits hides the hole in the middle of a trade."""
+    closes = [100.0, 90.0, 70.0, 50.0, 80.0, 110.0]
+    candles = make_candles(closes)
+    one_trade = [trade(candles[0]["date"], candles[-1]["date"], 100.0, 110.0, 10.0)]
+
+    sampled_at_exit = _max_drawdown_pct(one_trade, 10_000, candles=None)
+    marked_to_market = _max_drawdown_pct(one_trade, 10_000, candles=candles)
+
+    assert sampled_at_exit == 0.0, "a single winning trade shows no drawdown at exit"
+    assert marked_to_market == pytest.approx(50.0, abs=0.5), (
+        "equity halved mid-trade; that must surface"
+    )
+
+
+def test_calmar_uses_the_deeper_drawdown():
+    """Understating drawdown inflates Calmar, which divides by it."""
+    closes = [100.0, 60.0, 110.0]
+    candles = make_candles(closes)
+    one_trade = [trade(candles[0]["date"], candles[-1]["date"], 100.0, 110.0, 10.0)]
+
+    shallow = _calc_metrics(one_trade, 10_000, "1d")
+    deep = _calc_metrics(one_trade, 10_000, "1d", candles=candles)
+
+    assert abs(deep["max_drawdown_pct"]) > abs(shallow["max_drawdown_pct"])
+    assert abs(deep["calmar_ratio"]) < abs(shallow["calmar_ratio"] or 1e9)
+
+
+def test_drawdown_falls_back_cleanly_when_dates_do_not_match_candles():
+    """Walk-forward passes trades whose dates may sit outside the window."""
+    candles = make_candles([100.0, 105.0, 110.0])
+    orphan = [trade("1999-01-01", "1999-06-01", 100.0, 90.0, -10.0)]
+
+    dd = _max_drawdown_pct(orphan, 10_000, candles=candles)
+    assert dd == pytest.approx(10.0, abs=0.01), "must still sample at the exit"
+
+
+# ─── The empty case still holds ───────────────────────────────────────────────
+
+def test_no_trades_returns_the_empty_shape():
+    m = _calc_metrics([], 10_000, "1d")
+    assert m["total_trades"] == 0
+    assert m["final_capital"] == 10_000
+    json.dumps(m)  # must remain serialisable

--- a/tests/unit/services/test_metrics.py
+++ b/tests/unit/services/test_metrics.py
@@ -165,16 +165,29 @@ def test_intra_trade_drawdown_is_captured_when_candles_are_supplied():
 
 
 def test_calmar_uses_the_deeper_drawdown():
-    """Understating drawdown inflates Calmar, which divides by it."""
-    closes = [100.0, 60.0, 110.0]
-    candles = make_candles(closes)
-    one_trade = [trade(candles[0]["date"], candles[-1]["date"], 100.0, 110.0, 10.0)]
+    """Understating drawdown inflates Calmar, which divides by it.
 
-    shallow = _calc_metrics(one_trade, 10_000, "1d")
-    deep = _calc_metrics(one_trade, 10_000, "1d", candles=candles)
+    Both drawdowns must be non-zero for this to test anything: when equity
+    never dips at an exit, calmar_ratio is the 0.0 "undefined" sentinel and any
+    comparison against it is vacuous. So trade one loses, giving the
+    exit-sampled curve a real 20% drawdown, and trade two dips to half its
+    entry before closing green — visible only when marked to market.
+    """
+    candles = make_candles([100.0, 80.0, 100.0, 50.0, 50.0, 110.0])
+    trades = [
+        trade(candles[0]["date"], candles[1]["date"], 100.0, 80.0, -20.0),
+        trade(candles[2]["date"], candles[5]["date"], 100.0, 110.0, 10.0),
+    ]
 
-    assert abs(deep["max_drawdown_pct"]) > abs(shallow["max_drawdown_pct"])
-    assert abs(deep["calmar_ratio"]) < abs(shallow["calmar_ratio"] or 1e9)
+    shallow = _calc_metrics(trades, 10_000, "1d")
+    deep = _calc_metrics(trades, 10_000, "1d", candles=candles)
+
+    assert shallow["max_drawdown_pct"] == pytest.approx(-20.0, abs=0.1)
+    assert deep["max_drawdown_pct"] == pytest.approx(-60.0, abs=0.1)
+
+    # Same numerator, deeper denominator: Calmar must shrink, not stay put.
+    assert shallow["calmar_ratio"] != 0.0, "fixture must produce a real Calmar"
+    assert abs(deep["calmar_ratio"]) < abs(shallow["calmar_ratio"])
 
 
 def test_drawdown_falls_back_cleanly_when_dates_do_not_match_candles():
@@ -193,3 +206,12 @@ def test_no_trades_returns_the_empty_shape():
     assert m["total_trades"] == 0
     assert m["final_capital"] == 10_000
     json.dumps(m)  # must remain serialisable
+
+
+def test_result_shape_does_not_depend_on_whether_trades_fired():
+    """A client should not have to branch on trade count to read a key."""
+    empty = _calc_metrics([], 10_000, "1d")
+    populated = _calc_metrics(
+        [trade("2024-01-01", "2024-01-05", 100, 110, 10.0)], 10_000, "1d"
+    )
+    assert set(empty) == set(populated)

--- a/tests/unit/services/test_strategies.py
+++ b/tests/unit/services/test_strategies.py
@@ -1,0 +1,130 @@
+"""Correctness tests for the nine backtest strategy engines.
+
+These are pure functions over a list of candle dicts — no network, no mocks.
+Two of them shipped broken for want of exactly this file.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tradingview_mcp.core.services.backtest_service import (
+    _STRATEGY_MAP,
+    _SMA200_STRATEGIES,
+    _run_donchian,
+)
+from tradingview_mcp.core.services.indicators_calc import calc_donchian
+
+from ._synthetic import breakout_closes, make_candles, regime_closes
+
+
+@pytest.fixture(scope="module")
+def regime_candles() -> list[dict]:
+    return make_candles(regime_closes())
+
+
+@pytest.fixture(scope="module")
+def breakout_candles() -> list[dict]:
+    return make_candles(breakout_closes())
+
+
+# ─── No strategy is structurally dead ─────────────────────────────────────────
+
+@pytest.mark.parametrize("name", sorted(_STRATEGY_MAP))
+def test_strategy_produces_trades_on_a_series_designed_to_trigger_it(name, regime_candles):
+    """Every strategy must fire on a series containing every regime.
+
+    A strategy that returns zero trades on trending, oscillating, and crashing
+    data is not conservative — it is broken. `donchian` returned zero trades on
+    *every* input because its entry compared a bar's high against a channel
+    window that included that same high, which is never satisfiable.
+    """
+    trades = _STRATEGY_MAP[name](regime_candles)
+    assert trades, f"{name} produced no trades on a series built to trigger it"
+
+
+@pytest.mark.parametrize("name", sorted(_STRATEGY_MAP))
+def test_trades_are_well_formed_and_chronological(name, regime_candles):
+    trades = _STRATEGY_MAP[name](regime_candles)
+    for trade in trades:
+        assert trade["entry_price"] > 0
+        assert trade["exit_price"] > 0
+        assert trade["entry_date"] < trade["exit_date"], "exit must follow entry"
+
+    exits = [t["exit_date"] for t in trades]
+    entries = [t["entry_date"] for t in trades]
+    assert exits == sorted(exits), "trades must be emitted in order"
+    for prev_exit, next_entry in zip(exits, entries[1:]):
+        assert next_entry >= prev_exit, "positions must not overlap"
+
+
+# ─── No lookahead ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("name", sorted(_STRATEGY_MAP))
+def test_strategy_cannot_see_the_future(name, regime_candles):
+    """Truncating the series must not change trades that already closed.
+
+    If a strategy read any bar after a trade's exit, deleting those bars would
+    perturb that trade. Run the full series, then re-run on a prefix, and demand
+    the trades wholly inside the prefix are byte-identical.
+    """
+    full = _STRATEGY_MAP[name](regime_candles)
+    assert full, f"{name}: no trades to check"
+
+    # Cut a few bars after the first trade closes, so there is always at least
+    # one settled trade to compare regardless of how often the strategy fires.
+    dates = [c["date"] for c in regime_candles]
+    cutoff = dates.index(full[0]["exit_date"]) + 4
+    assert cutoff < len(regime_candles), f"{name}: first trade closes too late to truncate"
+
+    prefix = _STRATEGY_MAP[name](regime_candles[:cutoff])
+
+    boundary = regime_candles[cutoff - 1]["date"]
+    settled = [t for t in full if t["exit_date"] < boundary]
+
+    assert settled, f"{name}: no settled trades before the cutoff to compare"
+    assert prefix[:len(settled)] == settled, (
+        f"{name} changed a closed trade when future bars were removed — "
+        "this is lookahead bias"
+    )
+
+
+# ─── Donchian: the F-01 regression ────────────────────────────────────────────
+
+def test_donchian_enters_on_breakout_and_exits_on_breakdown(breakout_candles):
+    trades = _run_donchian(breakout_candles, period=20)
+
+    assert len(trades) == 1, f"expected one clean round trip, got {len(trades)}"
+    trade = trades[0]
+    assert trade["strategy"] == "donchian"
+
+    # Entry must land on the breakout, above the 100-102 chop that formed the
+    # channel — not inside it, and not at the very top of the run.
+    assert trade["entry_price"] > 102.0
+
+    # Exit must land on the way down, after the entry.
+    assert trade["exit_date"] > trade["entry_date"]
+    assert trade["exit_price"] < 132.0, "exit belongs on the breakdown, not the peak"
+
+
+def test_donchian_channel_window_includes_its_own_bar():
+    """Pin the invariant that made the original entry condition unsatisfiable.
+
+    `calc_donchian` builds upper[i] from a window *including* bar i. So
+    `highs[i] > upper[i]` is never true, and neither is `highs[i-1] >
+    upper[i-1]`. The strategy must therefore compare against the *previous*
+    bar's channel. If calc_donchian ever changes to an exclusive window, this
+    test fails and the strategy needs revisiting.
+    """
+    highs = [10, 11, 12, 13, 14, 15, 20, 25, 30, 35]
+    lows = [h - 1 for h in highs]
+    dc = calc_donchian(highs, lows, period=3)
+
+    for i, upper in enumerate(dc["upper"]):
+        if upper is not None:
+            assert highs[i] <= upper, "upper[i] must contain highs[i]"
+
+
+def test_donchian_does_not_trade_inside_its_own_channel():
+    """A flat series never breaks out. Guards against an over-eager fix."""
+    candles = make_candles([100.0 + (i % 3) for i in range(60)])
+    assert _run_donchian(candles, period=20) == []


### PR DESCRIPTION
Six correctness bugs in the backtest engine and volume scanner, the tests that catch them, and a CI job that runs those tests.

All six produce silently wrong output rather than errors — a user sees a clean, confident, plausible report. Every claim below is reproducible against `main` with the tests added in this PR.

## The two that matter most

**`donchian` never opened a position.** `calc_donchian` builds `upper[i]` from a window that *includes* bar `i`. The entry condition asked whether `highs[i-1] > upper[i-1]` — whether a value exceeds a maximum containing it. Never true. The exit was unreachable for the same reason (`close[i] >= low[i] >= lower[i]`). Every `donchian` backtest returned zero trades and a clean 0% report; in `compare_strategies` it always ranked last on merit it never had a chance to earn. The fix breaks the *previous* bar's channel, which excludes the current bar.

**Walk-forward robustness was inverted for losing strategies.** Dividing two negative returns yields a positive ratio, so a fold that lost 10% in-sample and 50% out-of-sample scored `te/tr = 5.0`, capped to the maximum `2.0`:

| Train | Test | Score | Verdict emitted |
|---|---|---|---|
| −10% | −50% | 2.00 | `ROBUST — strategy performs consistently` |
| −10% | −2% | 0.20 | `OVERFITTED — do not trade live` |
| +20% | +18% | 0.90 | `ROBUST` (correct) |

A strategy bleeding five times worse on unseen data got a green light; one that *improved* out-of-sample was flagged as overfit. This is the exact failure `walk_forward_backtest` exists to detect.

Scoring now lives in `_fold_robustness()`, which returns `0.0` when there is nothing to validate: no in-sample edge, or no trades in either window. Note `0/0` previously scored `1.0` — a perfect robustness score for a strategy that never traded, which is the only branch `donchian` ever hit.

## The other four

**`profit_factor` returned `float("inf")`** when a run had no losing trades. `json.dumps` emits that as the bare token `Infinity`, which is not valid JSON — a strict client fails to decode the *entire* tool response, not just that key. Now `None`, alongside a `no_losing_trades` flag.

**Sharpe annualised per-trade returns by the bar count.** `returns` is one entry per trade, but it was scaled by `sqrt(252)` as though a trade fired every bar. Ten trades in a year had their Sharpe inflated roughly 16×. On `main`, four trades spanning four *days* and four trades spanning four *years* both report `6.38`. Now derived from the trade dates, capped at the bar count.

**`max_drawdown` sampled equity only at trade exits,** so a drawdown that opened and closed inside a trade was invisible — and `calmar_ratio` divides by it. Both metrics skewed optimistic, in the same direction, compounding. Now marks the open position to market on every bar it is held when candles are available. This uses each bar's close, not its low, so it remains a lower bound on intraday pain — a much tighter one.

**`volume_breakout_scan` fabricated a passing volume ratio.** When `volume.SMA20` was absent upstream, the average was estimated as `volume / 2`, making `volume_ratio` identically `2.0` — which exactly meets the default `volume_multiplier=2.0`. Every symbol missing average-volume data auto-passed the "2× volume breakout" filter regardless of its actual volume. Missing data means the ratio is unknown, not `2.0`; the symbol is now skipped.

## Tests

`tests/unit/services/` gains `test_strategies.py`, `test_metrics.py`, and a deterministic `_synthetic.py` candle generator — no network, no randomness, no mocks. These are pure functions over a list of dicts and were among the easiest things in the repo to test.

- Every one of the nine strategies must produce trades on a series containing trending, oscillating, and crashing regimes. A strategy returning zero trades on that is not conservative, it is broken. **This is what catches `donchian`.**
- Every strategy must produce identical closed trades when future bars are truncated away — a lookahead-bias guard. *(All nine pass on `main` too; I found no lookahead bias in the engine, and this pins that.)*
- Trades are chronological and non-overlapping.
- The robustness, `profit_factor`, Sharpe-frequency, and drawdown regressions each have direct tests, including a strict-JSON round-trip that rejects `Infinity`.

Suite goes from 182 to 230 passing. I verified the new tests fail against unfixed source rather than passing vacuously.

## CI

`publish-image.yml` was the only workflow: every push to `main` built and pushed `:latest` to GHCR without running `pytest` once. The tests existed; nothing ran them, which is why the modules holding these bugs had no correctness coverage.

Adds a reusable `test.yml` across the four supported Python versions, and makes `build` depend on it — no image reaches GHCR from a commit whose tests fail. It installs with `uv pip install -e .` rather than setting `PYTHONPATH`, because without an install a bare `pytest` cannot import `tradingview_mcp` and collects nothing; a guard fails the job explicitly in that case, since a run collecting zero tests otherwise exits green.

## Compatibility

Two intentional behaviour changes worth calling out before merge:

1. **`profit_factor` changes type** from `float` to `float | None` when a run has no losing trades. Nothing in the repo sorts or formats on it, but downstream clients might.
2. **Walk-forward verdicts will change**, including for people whose reports previously said `ROBUST`. Folds where either window produced no trades now score `0.0` instead of `1.0`. Anyone who backtested `donchian` will see `ROBUST` become `OVERFITTED` — because the strategy was never trading at all. The old verdict was meaningless; the new one is accurate, but it will read as a regression.

Not addressed here, and happy to split into follow-ups: the Docker image binds `0.0.0.0` with no auth while the argparse default is correctly loopback; the `HEALTHCHECK` probes a `/health` route that does not exist; `core/portfolio.py` and the Marketaux-superseded `news_service.py` / `sentiment_service.py` are unreferenced, and `feedparser` remains a hard dependency serving no live code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
