### PR TITLE
feat: bulk price fetches — 1,000 tickers per request + fix silent 50-row cap

### DIFF
--- a/src/tradingview_mcp/core/services/stock_screener_service.py
+++ b/src/tradingview_mcp/core/services/stock_screener_service.py
@@ -43,8 +43,8 @@ _SCREEN_COLUMNS = (
 
 _PRICE_COLUMNS = ("name", "description", "exchange", "close", "currency", "change")
 
-MAX_SCREEN_LIMIT = 100
-MAX_PRICE_TICKERS = 50
+MAX_SCREEN_LIMIT = 1000
+MAX_PRICE_TICKERS = 1000
 
 
 def _clean(value: Any) -> Any:
@@ -136,7 +136,11 @@ def fetch_stock_prices(tickers: str) -> dict[str, Any]:
             f"invalid: {malformed}"
         )
 
-    query = Query().set_tickers(*parsed).select(*_PRICE_COLUMNS)
+    # .limit() is load-bearing: the scanner's default page size is 50, so
+    # without it a 1,000-ticker request silently returns only 50 rows
+    # (measured live 2026-07-14). With it, 1,000 prices come back in one
+    # HTTP request in ~0.5s.
+    query = Query().set_tickers(*parsed).select(*_PRICE_COLUMNS).limit(len(parsed))
     _total, df = query.get_scanner_data()
     found: dict[str, dict[str, Any]] = {}
     for r in df.to_dict("records"):

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -985,7 +985,7 @@ async def stock_screener(
         country: TradingView market name — e.g. america, korea, germany,
             brazil, japan, uk, india, turkey, canada, australia, france, hongkong
         stock_type: common | preferred
-        limit: rows to return (max 100), ranked by market cap descending
+        limit: rows to return (max 1000, single upstream request), ranked by market cap descending
 
     Returns:
         Envelope dict: total_matches (market-wide count), returned, and rows
@@ -1012,7 +1012,8 @@ async def stock_prices(tickers: str) -> dict:
     """Current price + daily % change for specific stock symbols.
 
     Args:
-        tickers: comma-separated EXCHANGE:SYMBOL list (max 50), e.g.
+        tickers: comma-separated EXCHANGE:SYMBOL list (max 1000 — one
+            upstream request even at full size), e.g.
             "NASDAQ:NVDA, NASDAQ:TSLA, KRX:005930". The exchange prefix is
             required — the scanner's direct-ticker lookup is exchange-scoped.
 


### PR DESCRIPTION
An integrator asked whether ~1,000 common-stock prices must be split across calls. No: the scanner serves 1,000+ rows in one HTTP request (~1.3s), so limits go 100/50 → **1000** on `stock_screener` / `stock_prices`.

**Bug fix along the way:** `set_tickers()` without `.limit()` silently truncates to the scanner's default 50-row page — a 1,000-ticker request returned exactly 50 prices with no error (measured live). `fetch_stock_prices` now sets `.limit(len(tickers))`, with a comment marking it load-bearing.

Live-verified: 1,000-row screen + 1,000-ticker price fetch, `not_found=[]`. tests/: 184 passed.