### PR TITLE
feat: exclude_otc (default on) + compact rows on stock_screener; limits to 2,000

### DIFF
--- a/src/tradingview_mcp/core/services/stock_screener_service.py
+++ b/src/tradingview_mcp/core/services/stock_screener_service.py
@@ -43,8 +43,8 @@ _SCREEN_COLUMNS = (
 
 _PRICE_COLUMNS = ("name", "description", "exchange", "close", "currency", "change")
 
-MAX_SCREEN_LIMIT = 1000
-MAX_PRICE_TICKERS = 1000
+MAX_SCREEN_LIMIT = 2000
+MAX_PRICE_TICKERS = 2000
 
 
 def _clean(value: Any) -> Any:
@@ -66,11 +66,31 @@ def screen_stocks(
     country: str = "america",
     stock_type: str = "common",
     limit: int = 50,
+    exclude_otc: bool = True,
+    compact: bool = False,
 ) -> dict[str, Any]:
     """Screen stocks of one share type for a country market.
 
     Returns an envelope: total_matches is the market-wide count, rows are the
     top-N by market cap.
+
+    exclude_otc (default True): TradingView's 'america' market means "trades
+    on a US venue", not "is a US company" — without this filter ~1/3 of the
+    top-100 is OTC foreign listings (Tencent, Roche, Nestlé...). Field-tested
+    on day one: a user asking for "the biggest 100 US stocks" got 29 OTC rows.
+    Pass exclude_otc=False to include them.
+
+    compact (default False): True trims rows to ticker/symbol/price/currency/
+    change_percent — for price-feed consumers pulling 1,000+ rows where the
+    full envelope is mostly dead weight.
+
+    Deliberately NOT deduplicated across share classes (GOOG/GOOGL, BRK.A/
+    BRK.B): those are distinct instruments with distinct real prices, and
+    which one is "canonical" is a consumer-side decision, not a data-layer one.
+
+    change_percent can be null (fresh listings before their first full
+    session, e.g. SKHY on IPO day). Deliberately NOT defaulted to 0 — "no
+    change data" and "0% change" are different facts; null-check downstream.
     """
     _require_available()
     stock_type = (stock_type or "common").strip().lower()
@@ -81,11 +101,14 @@ def screen_stocks(
     country = (country or "america").strip().lower()
     limit = max(1, min(int(limit), MAX_SCREEN_LIMIT))
 
+    filters = [col("type") == "stock", col("typespecs").has([stock_type])]
+    if exclude_otc:
+        filters.append(col("exchange") != "OTC")
     query = (
         Query()
         .set_markets(country)
         .select(*_SCREEN_COLUMNS)
-        .where(col("type") == "stock", col("typespecs").has([stock_type]))
+        .where(*filters)
         .order_by("market_cap_basic", ascending=False)
         .limit(limit)
     )
@@ -104,9 +127,13 @@ def screen_stocks(
         }
         for r in df.to_dict("records")
     ]
+    if compact:
+        keep = ("ticker", "symbol", "price", "currency", "change_percent")
+        rows = [{k: r[k] for k in keep} for r in rows]
     return {
         "country": country,
         "stock_type": stock_type,
+        "exclude_otc": exclude_otc,
         "total_matches": total,
         "returned": len(rows),
         "rows": rows,

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -976,7 +976,11 @@ def futures_watchlist() -> dict:
 
 @mcp.tool()
 async def stock_screener(
-    country: str = "america", stock_type: str = "common", limit: int = 50
+    country: str = "america",
+    stock_type: str = "common",
+    limit: int = 50,
+    exclude_otc: bool = True,
+    compact: bool = False,
 ) -> dict:
     """Screen stocks by share type — the API twin of TradingView's
     "Common stock" / "Preferred stock" symbol-search filter.
@@ -985,7 +989,11 @@ async def stock_screener(
         country: TradingView market name — e.g. america, korea, germany,
             brazil, japan, uk, india, turkey, canada, australia, france, hongkong
         stock_type: common | preferred
-        limit: rows to return (max 1000, single upstream request), ranked by market cap descending
+        limit: rows to return (max 2000, single upstream request), ranked by market cap descending
+        exclude_otc: default True — drop OTC listings (foreign companies traded
+            over-the-counter); "america" otherwise means "US venue", not "US company"
+        compact: default False — True returns only ticker/symbol/price/currency/
+            change_percent per row (light payload for bulk price feeds)
 
     Returns:
         Envelope dict: total_matches (market-wide count), returned, and rows
@@ -996,7 +1004,9 @@ async def stock_screener(
     try:
         # tradingview-screener is sync (urllib) — off-load to a worker thread
         # so the event loop stays free for concurrent tool calls.
-        return await asyncio.to_thread(screen_stocks, country, stock_type, limit)
+        return await asyncio.to_thread(
+            screen_stocks, country, stock_type, limit, exclude_otc, compact
+        )
     except ValueError as e:
         return make_error(ErrorCode.INVALID_PARAMETER, str(e))
     except Exception as e:
@@ -1012,7 +1022,7 @@ async def stock_prices(tickers: str) -> dict:
     """Current price + daily % change for specific stock symbols.
 
     Args:
-        tickers: comma-separated EXCHANGE:SYMBOL list (max 1000 — one
+        tickers: comma-separated EXCHANGE:SYMBOL list (max 2000 — one
             upstream request even at full size), e.g.
             "NASDAQ:NVDA, NASDAQ:TSLA, KRX:005930". The exchange prefix is
             required — the scanner's direct-ticker lookup is exchange-scoped.


### PR DESCRIPTION
Day-one field feedback from a real consumer pulling US common-stock prices.

- **exclude_otc=True default** — 'america' means "US venue", not "US company": ~1/3 of the top-100 was OTC foreign listings (Tencent, Roche, Nestlé, ICBC…). Clean default = NYSE+NASDAQ+AMEX (universe 10,975 → 5,173); `exclude_otc=False` restores old behavior.
- **compact=True** — rows trimmed to ticker/symbol/price/currency/change_percent: 1,000 rows go 237KB → 113KB.
- **Limits 1000 → 2000** on both tools (live-verified: 2,000 prices in one `set_tickers` request).
- Two deliberate NON-changes documented in docstrings: no share-class dedup (GOOG/GOOGL, BRK.A/BRK.B are distinct instruments), and `change_percent` stays `null` on fresh listings ("no data" ≠ "0%").

tests/: 184 passed.