### PR TITLE
feat: daily OHLC (open/high/low) on stock_screener + stock_prices rows

### DIFF
--- a/src/tradingview_mcp/core/services/stock_screener_service.py
+++ b/src/tradingview_mcp/core/services/stock_screener_service.py
@@ -37,11 +37,14 @@ EXAMPLE_MARKETS = (
 )
 
 _SCREEN_COLUMNS = (
-    "name", "description", "exchange", "close", "currency",
-    "change", "dividends_yield_current", "market_cap_basic",
+    "name", "description", "exchange", "open", "high", "low", "close",
+    "currency", "change", "dividends_yield_current", "market_cap_basic",
 )
 
-_PRICE_COLUMNS = ("name", "description", "exchange", "close", "currency", "change")
+_PRICE_COLUMNS = (
+    "name", "description", "exchange", "open", "high", "low", "close",
+    "currency", "change",
+)
 
 MAX_SCREEN_LIMIT = 2000
 MAX_PRICE_TICKERS = 2000
@@ -120,6 +123,9 @@ def screen_stocks(
             "description": _clean(r.get("description")),
             "exchange": _clean(r.get("exchange")),
             "price": _clean(r.get("close")),
+            "open": _clean(r.get("open")),
+            "high": _clean(r.get("high")),
+            "low": _clean(r.get("low")),
             "currency": _clean(r.get("currency")),
             "change_percent": _clean(r.get("change")),
             "dividend_yield": _clean(r.get("dividends_yield_current")),
@@ -177,6 +183,9 @@ def fetch_stock_prices(tickers: str) -> dict[str, Any]:
             "description": _clean(r.get("description")),
             "exchange": _clean(r.get("exchange")),
             "price": _clean(r.get("close")),
+            "open": _clean(r.get("open")),
+            "high": _clean(r.get("high")),
+            "low": _clean(r.get("low")),
             "currency": _clean(r.get("currency")),
             "change_percent": _clean(r.get("change")),
         }

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -997,8 +997,9 @@ async def stock_screener(
 
     Returns:
         Envelope dict: total_matches (market-wide count), returned, and rows
-        of {ticker, symbol, description, exchange, price, currency,
-        change_percent, dividend_yield, market_cap}. Prices are in the
+        of {ticker, symbol, description, exchange, price, open, high, low,
+        currency, change_percent, dividend_yield, market_cap} — price is the
+        current/last close; open/high/low are the current session's daily bar. Prices are in the
         market's local currency (e.g. KRW for korea).
     """
     try:
@@ -1029,7 +1030,7 @@ async def stock_prices(tickers: str) -> dict:
 
     Returns:
         Envelope dict: rows of {ticker, symbol, description, exchange, price,
-        currency, change_percent} plus a not_found list naming any requested
+        open, high, low, currency, change_percent} plus a not_found list naming any requested
         ticker the scanner didn't recognize.
     """
     try:


### PR DESCRIPTION
Pre-sales question from a real prospect: *"do you provide OHLC data for Australian shares via ASX?"* — the scanner already serves the current session's daily bar, the tools just didn't select the columns.

- `open`/`high`/`low` added to both tools' rows; `price` remains the current/last close (no field renames — existing consumers unaffected; `compact` mode intentionally unchanged).
- **ASX verified live:** australia market = 1,621 common stocks; BHP O 60.90 / H 61.27 / L 60.56 / C 60.56 AUD; `ASX:BHP`-style direct lookups work.

tests/: 184 passed.