### PR TITLE
feat: server-side sort_by on stock_screener

### DIFF
--- a/src/tradingview_mcp/core/services/stock_screener_service.py
+++ b/src/tradingview_mcp/core/services/stock_screener_service.py
@@ -49,6 +49,17 @@ _PRICE_COLUMNS = (
 MAX_SCREEN_LIMIT = 2000
 MAX_PRICE_TICKERS = 2000
 
+# sort_by -> scanner column. Every entry must also be in _SCREEN_COLUMNS.
+# Field-tested motivation: without a server-side sort, "top dividend payers"
+# can only be computed inside the market-cap-ranked window the caller pulled —
+# the real leaders in the long tail stay invisible.
+SORT_FIELDS = {
+    "market_cap": "market_cap_basic",
+    "dividend_yield": "dividends_yield_current",
+    "change": "change",
+    "price": "close",
+}
+
 
 def _clean(value: Any) -> Any:
     """NaN -> None so rows serialize to JSON cleanly."""
@@ -71,11 +82,14 @@ def screen_stocks(
     limit: int = 50,
     exclude_otc: bool = True,
     compact: bool = False,
+    sort_by: str = "market_cap",
 ) -> dict[str, Any]:
     """Screen stocks of one share type for a country market.
 
     Returns an envelope: total_matches is the market-wide count, rows are the
-    top-N by market cap.
+    top-N by sort_by (market_cap | dividend_yield | change | price — always
+    descending, server-side, so the ranking covers the WHOLE market, not just
+    the window the caller happened to pull).
 
     exclude_otc (default True): TradingView's 'america' market means "trades
     on a US venue", not "is a US company" — without this filter ~1/3 of the
@@ -90,6 +104,11 @@ def screen_stocks(
     Deliberately NOT deduplicated across share classes (GOOG/GOOGL, BRK.A/
     BRK.B): those are distinct instruments with distinct real prices, and
     which one is "canonical" is a consumer-side decision, not a data-layer one.
+    Known limitation in the same family: exchange-specific quotation lines
+    (e.g. ASX deferred-settlement tickers like MTSCD next to MTS) carry
+    type=stock + typespecs=[common] and are indistinguishable in scanner
+    fields — filtering them by ticker-suffix heuristics would risk false
+    positives on real symbols, so they are passed through as-is.
 
     change_percent can be null (fresh listings before their first full
     session, e.g. SKHY on IPO day). Deliberately NOT defaulted to 0 — "no
@@ -103,6 +122,11 @@ def screen_stocks(
         )
     country = (country or "america").strip().lower()
     limit = max(1, min(int(limit), MAX_SCREEN_LIMIT))
+    sort_col = SORT_FIELDS.get((sort_by or "market_cap").strip().lower())
+    if not sort_col:
+        raise ValueError(
+            f"sort_by must be one of {list(SORT_FIELDS)}, got {sort_by!r}"
+        )
 
     filters = [col("type") == "stock", col("typespecs").has([stock_type])]
     if exclude_otc:
@@ -112,7 +136,7 @@ def screen_stocks(
         .set_markets(country)
         .select(*_SCREEN_COLUMNS)
         .where(*filters)
-        .order_by("market_cap_basic", ascending=False)
+        .order_by(sort_col, ascending=False)
         .limit(limit)
     )
     total, df = query.get_scanner_data()
@@ -140,6 +164,7 @@ def screen_stocks(
         "country": country,
         "stock_type": stock_type,
         "exclude_otc": exclude_otc,
+        "sort_by": sort_by,
         "total_matches": total,
         "returned": len(rows),
         "rows": rows,

--- a/src/tradingview_mcp/server.py
+++ b/src/tradingview_mcp/server.py
@@ -981,6 +981,7 @@ async def stock_screener(
     limit: int = 50,
     exclude_otc: bool = True,
     compact: bool = False,
+    sort_by: str = "market_cap",
 ) -> dict:
     """Screen stocks by share type — the API twin of TradingView's
     "Common stock" / "Preferred stock" symbol-search filter.
@@ -994,6 +995,10 @@ async def stock_screener(
             over-the-counter); "america" otherwise means "US venue", not "US company"
         compact: default False — True returns only ticker/symbol/price/currency/
             change_percent per row (light payload for bulk price feeds)
+        sort_by: market_cap (default) | dividend_yield | change | price —
+            server-side descending sort over the WHOLE market, so e.g.
+            sort_by=dividend_yield with limit=20 is the market's true top-20
+            dividend payers, not just the biggest companies re-sorted
 
     Returns:
         Envelope dict: total_matches (market-wide count), returned, and rows
@@ -1006,7 +1011,7 @@ async def stock_screener(
         # tradingview-screener is sync (urllib) — off-load to a worker thread
         # so the event loop stays free for concurrent tool calls.
         return await asyncio.to_thread(
-            screen_stocks, country, stock_type, limit, exclude_otc, compact
+            screen_stocks, country, stock_type, limit, exclude_otc, compact, sort_by
         )
     except ValueError as e:
         return make_error(ErrorCode.INVALID_PARAMETER, str(e))


### PR DESCRIPTION
Connector-test feedback: with sorting fixed to market cap, "top dividend payers" could only be computed client-side inside the pulled window — long-tail leaders stayed invisible. **Measured on ASX:** best yield inside the top-200-by-cap window = 12.0% (SPK); true market-wide leader = **48.6% (STP)** — SPK doesn't even make the real top 10.

- `sort_by`: `market_cap` (default, unchanged) | `dividend_yield` | `change` | `price`, server-side descending, validated.
- Envelope echoes `sort_by`.
- Docstring documents the deliberately-unfixed quotation-line limitation (ASX MTSCD vs MTS: identical type/typespecs in scanner fields; suffix heuristics risk false positives).

tests/: 184 passed.