### PR TITLE
fix(deps): pin mcp[cli] below 2 — 0.8.0 release (mcp 2.0.0 breaks fresh installs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,20 @@
 # 3. .env is in .gitignore — it will NEVER be committed to git
 # =============================================================
 
+# ── News (Optional — Marketaux) ───────────────────────────────
+# financial_news / news-driven sentiment use the licensed Marketaux API
+# (replaced the old RSS/Reddit scraping). Get a token at
+# https://www.marketaux.com — without it the news tools return empty
+# results (every other tool works normally).
+
+MARKETAUX_API_TOKEN=your_marketaux_token_here
+# Max Marketaux requests per day before serving cached/stub results
+MARKETAUX_DAILY_BUDGET=90
+
 # ── Proxy (Optional — Webshare Rotating Residential) ──────────
 # Get credentials from: https://proxy.webshare.io/proxy/list
-# Enables access to Yahoo Finance, Xueqiu, and reduces Reddit rate-limits.
-# Leave blank to run WITHOUT proxy (Reddit & RSS will still work).
+# Enables access to Yahoo Finance and Xueqiu behind rate-limits.
+# Leave blank to run WITHOUT proxy (TradingView tools work fine without it).
 
 PROXY_HOST=p.webshare.io
 PROXY_PORT=80

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-29
+
 ### Fixed
+- **CRITICAL — pinned `mcp[cli]>=1.12.0,<2`**: `mcp` 2.0.0 (released 2026-07-28
+  alongside the MCP 2026-07-28 stateless spec) removes the `mcp.server.fastmcp`
+  module this server imports. 0.7.1's published metadata carries the open
+  `>=1.12.0` range, so every fresh `pip install` / `uvx` since 2026-07-28
+  resolved mcp 2.0.0 and died on startup with
+  `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. Upgrade to
+  0.8.0 to get a working install. Migrating to the 2.x SDK
+  (FastMCP → MCPServer) will be a deliberate follow-up release.
+- **`volume_confirmation_analysis` bare-symbol failures**: bare crypto symbols
+  (no exchange prefix) failed ~99% of the time; symbols are now resolved
+  before analysis.
+- **Donchian breakout off-by-one**: the breakout strategy read a window that
+  included the current bar, inflating backtest results; window is now strictly
+  historical (regression-tested).
+- **Backtest input validation**: initial capital and cost parameters are now
+  validated instead of silently producing nonsense results.
 - **`coin_analysis` ATR null bug**: `tradingview_ta` omits the `ATR` column from
   its analysis payload, which left `indicators["ATR"]` (and every downstream
   consumer — stop-loss sizing, trade-quality score, volatility metrics) at
@@ -17,7 +35,37 @@ All notable changes to this project will be documented in this file.
   screener column logic (`5m→5`, `15m→15`, `1h→60`, `4h→240`, `1D/1W/1M`
   unchanged); unknown timeframes degrade to the unsuffixed `ATR` column.
 
+### Added
+- **Markets**: Taiwan (TWSE, TPEX), Saudi Arabia (TADAWUL), US futures across
+  CME/COMEX/NYMEX/CBOT (equity index, energy, metals, agriculture, rates, FX,
+  crypto futures), AMEX/NYSEARCA aliases, auto-venue fallback for unlisted
+  symbols, precious-metal futures resolution via TVC.
+- **Tools**: `stock_screener` + `stock_prices` (bulk fetches up to 1,000 rows,
+  `exclude_otc`, server-side sorting, daily OHLC), `stock_options_chain` +
+  `stock_options_unusual_activity`, `stock_extended_hours`,
+  `bitcoin_market_pulse`.
+- **Directory-grade tool metadata**: every tool now ships `title`,
+  `readOnlyHint`, and an explicit `destructiveHint=False` annotation.
+- **Multi-arch Docker image CI**: GHCR images built for linux/amd64 +
+  linux/arm64 on every push to main and on version tags.
+
 ### Changed
+- **Every tool now runs off the event loop** (blanket async offload) — a slow
+  upstream call can no longer block the MCP server's event loop.
+- **Structured error envelopes everywhere**: screener/scanner failures return
+  machine-readable envelopes with retryability signals and symbol
+  suggestions instead of bare strings; note that tool return types are now
+  `list[dict] | dict` (consumers that assumed a bare list should handle the
+  envelope shape).
+- **News pipeline**: RSS/Reddit scraping replaced with the licensed Marketaux
+  API. Set `MARKETAUX_API_TOKEN` (see `.env.example`) to enable
+  `financial_news` and news-driven sentiment; without a token the news tools
+  return empty results while everything else works normally.
+- **Reliability**: bounded HTTP timeouts with stale-while-error fallback,
+  retry + 60s TTL response cache, `tradingview_ta` request throttling,
+  fast-fail on upstream outages.
+- Python support capped below 3.14 (`requires-python >=3.10,<3.14`) until the
+  dependency stack publishes 3.14 wheels.
 - `requests` is now an explicit dependency in `pyproject.toml`. It was already
   pulled in transitively by `tradingview-screener` / `tradingview-ta`, but the
   new ATR injection path uses it directly, so it is no longer safe to rely on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tradingview-mcp-server"
-version = "0.7.1"
+version = "0.8.0"
 description = "Advanced AI Trading Intelligence Framework — MCP server with walk-forward backtesting, trade logs, equity curves, 1h timeframe, sentiment, Yahoo Finance, and 30+ technical analysis tools"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -20,7 +20,12 @@ classifiers = [
 dependencies = [
   "feedparser>=6.0.12",
   "httpx>=0.27",
-  "mcp[cli]>=1.12.0",
+  # Capped below 2. mcp 2.0.0 (2026-07-28, the stateless-spec SDK rework)
+  # removes the `mcp.server.fastmcp` module our server imports, so an open
+  # range breaks every fresh install (and any Docker rebuild — `uv pip
+  # install --system .` ignores uv.lock). Moving to the 2.x SDK
+  # (FastMCP -> MCPServer) is a deliberate migration, not a drive-by resolve.
+  "mcp[cli]>=1.12.0,<2",
   "requests>=2.32",
   # Pinned to ==3.0.0 on purpose. 3.2.0 makes a bare Query() default to a
   # *stock* preset filter that silently returns 0 rows for crypto/futures

--- a/uv.lock
+++ b/uv.lock
@@ -958,7 +958,7 @@ wheels = [
 
 [[package]]
 name = "tradingview-mcp-server"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "feedparser" },
@@ -979,7 +979,7 @@ dev = [
 requires-dist = [
     { name = "feedparser", specifier = ">=6.0.12" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.12.0,<2" },
     { name = "requests", specifier = ">=2.32" },
     { name = "tradingview-screener", specifier = "==3.0.0" },
     { name = "tradingview-ta", specifier = ">=3.3.0" },


### PR DESCRIPTION
## Why

`mcp` 2.0.0 (released 2026-07-28 alongside the MCP 2026-07-28 stateless spec) **removes the `mcp.server.fastmcp` module** this server imports at `src/tradingview_mcp/server.py:18`. Our dependency range was open (`mcp[cli]>=1.12.0`), so:

- every fresh `pip install tradingview-mcp-server` / `uvx` since 2026-07-28 resolves mcp 2.0.0 and dies on startup with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`
- the next Docker image rebuild would hit the same cliff (`uv pip install --system .` ignores `uv.lock`) — same failure class as the tradingview-screener 3.2.0 incident

## What

- pin `mcp[cli]>=1.12.0,<2` with a comment explaining why (2.x migration = deliberate follow-up)
- version 0.7.1 → **0.8.0** (first PyPI release since April; ~63 commits of markets/tools/async/error-envelope work ship with it)
- CHANGELOG: full 0.8.0 entry
- `.env.example`: document `MARKETAUX_API_TOKEN` / `MARKETAUX_DAILY_BUDGET` (news moved from RSS/Reddit to Marketaux after 0.7.1; stale proxy note fixed)
- `uv lock` refresh (only version + specifier change; locked mcp stays 1.12.4)

## Verification (all on this branch)

- clean py3.12 venv, `uv pip install .` → resolves **mcp 1.29.0** + `tradingview-screener==3.0.0` intact
- `import tradingview_mcp.server` OK; `tradingview-mcp --help` OK
- real handshake: `tradingview-mcp streamable-http --port 8123` + JSON-RPC `initialize` → serverInfo returned, `tools/list` → **37 tools**
- repro of the breakage: clean venv + `mcp==2.0.0` → `ModuleNotFoundError` (confirms the pin is load-bearing)
- `uv build`: wheel is 0.8.0 and ships all 29 `coinlist/*.txt` (incl. new mexc/twse/tpex)
- `uv run pytest tests/`: **227 passed**, 8 deselected (stress)

After merge: tag `v0.8.0` (CI publishes the semver image) and publish 0.8.0 to PyPI so fresh installs are fixed.