### PR TITLE
docs: add OrcaRouter as an OpenClaw provider option

### DIFF
--- a/OPENCLAW.md
+++ b/OPENCLAW.md
@@ -119,6 +119,32 @@ print('✅ API key also written to models.json')
 
 > **Note:** Replace `YOUR_KEY_HERE` with your actual OpenRouter key in both commands above.
 
+**Step 4e — Alternative: use OrcaRouter instead**
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenRouter-compatible aggregator — one API key gives you access to Claude, GPT, Gemini and more. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+1. Go to [orcarouter.ai](https://www.orcarouter.ai) and create a key (it starts with `sk-orca-`).
+2. Add OrcaRouter as a provider and point the agent at it (replace `YOUR_KEY_HERE` with your actual key):
+
+```bash
+python3 -c "
+import json
+with open('/root/.openclaw/openclaw.json', 'r') as f:
+    cfg = json.load(f)
+cfg.setdefault('models', {}).setdefault('providers', {})['orcarouter'] = {
+    'baseUrl': 'https://api.orcarouter.ai/v1',
+    'apiKey': 'YOUR_KEY_HERE',
+    'api': 'openai-completions',
+}
+cfg.setdefault('agents', {}).setdefault('defaults', {})['model'] = 'orcarouter/openai/gpt-5.5'
+with open('/root/.openclaw/openclaw.json', 'w') as f:
+    json.dump(cfg, f, indent=2)
+print('✅ OrcaRouter provider configured')
+"
+```
+
+3. Skip steps 4c–4d above — the OrcaRouter key is already in place.
+
 ### 5. Restart OpenClaw
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ OpenRouter is **not required** — use whichever provider you have a key for:
 | Provider | Model ID for OpenClaw | Get Key |
 |----------|----------------------|---------|
 | **OpenRouter** (aggregator — access to all models) | `openrouter/google/gemini-3-flash-preview` | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| **OrcaRouter** (OpenRouter-compatible aggregator — one key for Claude, GPT & Gemini) | `orcarouter/openai/gpt-5.5` | [orcarouter.ai](https://www.orcarouter.ai) |
 | **Anthropic** (Claude direct) | `anthropic/claude-sonnet-4-5` | [console.anthropic.com](https://console.anthropic.com) |
 | **Google** (Gemini direct) | `google/gemini-2.5-flash` | [aistudio.google.com](https://aistudio.google.com) |
 | **OpenAI** (GPT direct) | `openai/gpt-4o-mini` | [platform.openai.com](https://platform.openai.com) |
@@ -347,11 +348,12 @@ OpenRouter is **not required** — use whichever provider you have a key for:
 ```bash
 # Examples — set your chosen model:
 openclaw config set agents.defaults.model "openrouter/google/gemini-3-flash-preview"  # via OpenRouter
+openclaw config set agents.defaults.model "orcarouter/openai/gpt-5.5"                 # via OrcaRouter
 openclaw config set agents.defaults.model "anthropic/claude-sonnet-4-5"               # Anthropic direct
 openclaw config set agents.defaults.model "google/gemini-2.5-flash"                   # Google direct
 ```
 
-> ⚠️ **Important:** Prefix must match your provider. `google/...` needs a Google API key. `openrouter/...` needs an OpenRouter key.
+> ⚠️ **Important:** Prefix must match your provider. `google/...` needs a Google API key. `openrouter/...` needs an OpenRouter key. For `orcarouter/...`, register the provider first — see [OPENCLAW.md](OPENCLAW.md) Step 4e.
 
 ### ⚠️ Common Mistakes
 


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a named model-provider option in the OpenClaw setup docs. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- `README.md`: added an OrcaRouter row to the "Choose Your AI Model" provider table (`orcarouter/openai/gpt-5.5`), the matching `openclaw config set` example, and a note pointing to the setup steps.
- `OPENCLAW.md`: added Step 4e "Alternative: use OrcaRouter instead", mirroring the existing OpenRouter setup — it registers OrcaRouter as a custom OpenClaw provider (`models.providers.orcarouter` with `baseUrl` `https://api.orcarouter.ai/v1` and the `openai-completions` adapter) and points the agent at it.

## Verification

- Live connectivity: `openai/gpt-5.5` via `https://api.orcarouter.ai/v1/chat/completions` returns 200 and resolves to `gpt-5.5-2026-04-24`.
- The Step 4e config snippet was executed against a minimal `openclaw.json`; it produces the expected `models.providers.orcarouter` block plus the `agents.defaults.model` entry.
- Docs-only change (no Python or workflow files touched).

I'm an engineer on the OrcaRouter team.
